### PR TITLE
Added optionId field to PaymentAppRequestData dictionary

### DIFF
--- a/index.html
+++ b/index.html
@@ -1058,6 +1058,7 @@
         sequence&lt;PaymentMethodData&gt; methodData;
         PaymentItem total;
         sequence&lt;PaymentDetailsModifier&gt; modifiers;
+        DOMString optionId;
       };
     </pre>
     <dl>
@@ -1094,6 +1095,12 @@
         per-payment-method basis).  It is populated from the
         <a>PaymentRequest</a> using the <a>Modifiers Population Algorithm</a>
         defined below.
+      </dd>
+      <dt><code>optionId</code> attribute</dt>
+      <dd>
+        This attribute indicates which <a>PaymentAppOption</a> the user
+        selected. It corresponds to the <code>id</code> field provided during
+        payment app registration.
       </dd>
     </dl>
     <section>


### PR DESCRIPTION
Although it's mentioned as part of the registration process, I missed adding this on my first set of edits to the payment request process.
