### PR TITLE
add parens for clause

### DIFF
--- a/index.html
+++ b/index.html
@@ -741,9 +741,9 @@
           <li>
             Ask the user whether they allow the <a>payment app</a> to be
             registered to handle the indicated <a>payment methods</a>
-            unless a prearranged trust relationship applies or the user has
+            (unless a prearranged trust relationship applies or the user has
             already granted or denied permission explicitly for this <a>payment
-            app</a>.
+            app</a>).
           </li>
           <li>
             If permission is not granted, reject <var>promise</var> with a


### PR DESCRIPTION
Seemed that the dependent clause read better when enclosed in parenthesis
