### PR TITLE
(Promise<PaymentResponse> or PaymentResponse) is invalid Web IDL.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1341,8 +1341,7 @@
       [Exposed=ServiceWorker]
       interface PaymentRequestEvent : ExtendableEvent {
         readonly attribute PaymentAppRequestData data;
-        void respondWith((<a>Promise</a>&lt;<a>PaymentResponse</a>&gt;
-        or <a>PaymentResponse</a>) r);
+        void respondWith(<a>Promise</a>&lt;<a>PaymentResponse</a>&gt;response);
       };
       </pre>
       <dl>


### PR DESCRIPTION
Should just be Promise<PaymentResponse>.
Existing case: https://github.com/w3c/ServiceWorker/issues/724