### PR TITLE
Modify section 10.4 Payment App Response to allow an app to cancel.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1470,11 +1470,28 @@
       function of the corresponding <a>PaymentRequestEvent</a> dictionary.
       The application is expected to resolve the Promise with a
       <code>PaymentResponse</code> dictionary instance containing the payment
-      response information.
+      response information. In case of user cancellation or error, the
+      application may signal failure by rejecting the Promise.
     </p>
     <p>
-      When this Promise is resolved, the user agent MUST run the <a>user
-      accepts the payment request algorithm</a> as defined in
+      If the Promise is rejected, the user agent MUST run the <dfn>payment app
+      failure algorithm</dfn>. The exact details of this algorithm is left for
+      user agent implementers to decide on. Acceptable behaviors include,
+      but are not limited to:
+    </p>
+    <ul>
+      <li>
+        Letting the user try again, with the same payment app or with a
+        different one.
+      </li>
+      <li>
+        Rejecting the Promise that was created by
+        <code>PaymentRequest.show()</code>.
+      </li>
+    </ul>
+    <p>
+      If this Promise is successfully resolved, the user agent MUST run the
+      <a>user accepts the payment request algorithm</a> as defined in
       [[!PAYMENT-REQUEST-API]], replacing steps 6 and 7 with these steps or
       their equivalent:
     </p>
@@ -1486,9 +1503,8 @@
       <li>
         If <var>appResponse</var>.<code>methodName</code> is not present or
         not set to one of the values from
-        <a>PaymentRequestEvent</a>.<code>data</code>, reject the Promise
-        created by <code>PaymentRequest.show()</code> with <a>DOMException</a>
-        whose value "<a>InvalidStateError</a>" and terminate these steps.
+        <a>PaymentRequestEvent</a>.<code>data</code>, run the <a>payment app
+        failure algorithm</a> and terminate these steps.
       </li>
       <li>
         Create a <a>structured clone</a> of
@@ -1497,10 +1513,8 @@
         <var>response</var>.<code>methodName</code>.
       </li>
       <li>
-        If <var>appResponse</var>.<code>details</code> is not present,
-        reject the Promise created by
-        <code>PaymentRequest.show()</code> with a <a>DOMException</a> whose
-        value is "<a>InvalidStateError</a>" and terminate these steps.
+        If <var>appResponse</var>.<code>details</code> is not present, run the
+        <a>payment app failure algorithm</a> and terminate these steps.
       </li>
       <li>
         Create a <a>structured clone</a> of
@@ -1509,12 +1523,6 @@
         <var>response</var>.<code>details</code>.
       </li>
     </ol>
-    <p>
-      The user agent receives a failure response from the payment app through
-      rejection of the Promise.  The user agent MUST use the rejection reason
-      to reject the Promise that was created by
-      <code>PaymentRequest.show()</code>.
-    </p>
 
     <p>The following example shows how to respond to a payment request:</p>
     <pre class="example highlight" title="Sending a Payment Response">


### PR DESCRIPTION
This change designate rejection of the Promise provided to respondWith
as an acceptable way to cancel out of a payment app. How the user agent
wants to handle rejection of this Promise is left open, but allowing for
retries, or trying a different app is encouraged.