### PR TITLE
The instrumnets/wallets attributes should be readonly and [SameObject].

### DIFF
--- a/index.html
+++ b/index.html
@@ -338,8 +338,8 @@
       <h2><a>PaymentManager</a> interface</h2>
       <pre id="payment-manager-idl" class="idl">
       interface PaymentManager {
-        attribute PaymentInstruments instruments;
-        attribute PaymentWallets wallets;
+        [SameObject] readonly attribute PaymentInstruments instruments;
+        [SameObject] readonly attribute PaymentWallets wallets;
       };
       </pre>
       <dl>


### PR DESCRIPTION
The attributes should be readonly because the PaymentInstruments and
PaymentWallets doesn't have constructor and developers can not set.
Also, it's better to mark [SameObject] because we don't need to create a new
object whenever accessing those attributes.