### PR TITLE
Add support for topLevelOrigin and paymentRequestOrigin

### DIFF
--- a/index.html
+++ b/index.html
@@ -415,7 +415,7 @@
             <ol>
               <li>Resolve <var>p</var> with a <dfn>Sequence</dfn> that contains all
               the <var>instrumentKey</var>s for the <a>PaymentInstrument</a>s
-              contained in the collection.
+              contained in the collection, in original insertion order.
             </ol>
             <li> Return <var>p</var></li>
           </ol>
@@ -575,7 +575,7 @@
             <ol>
               <li>Resolve <var>p</var> with a sequence that contains all
               the <var>walletKey</var>s for the <a>PaymentWallet</a>s
-              contained in the collection.
+              contained in the collection, in original insertion order.
             </ol>
             <li> Return <var>p</var></li>
           </ol>

--- a/index.html
+++ b/index.html
@@ -177,9 +177,8 @@
     <dl>
       <dt>Payment Request API</dt>
       <dd>The terms <dfn>payment method</dfn>, <dfn>PaymentRequest</dfn>,
-      <dfn>PaymentResponse</dfn>, <dfn>supportedMethods</dfn>, <dfn>paymentDetailsModifier</dfn>, <dfn>paymentDetails</dfn>, <dfn>PaymentMethodData</dfn>, <dfn>ID</dfn>, and <dfn>user accepts the payment
-      request algorithm</dfn> are defined by the Payment Request
-      API specification [[!PAYMENT-REQUEST-API]].</dd>
+      <dfn>PaymentResponse</dfn>, <dfn>supportedMethods</dfn>, <dfn>paymentDetailsModifier</dfn>, <dfn>paymentDetails</dfn>, <dfn>PaymentMethodData</dfn>, <dfn>ID</dfn> and <dfn>user accepts the payment request algorithm</dfn>  are defined by the Payment Request
+      API specification [[!PAYMENT-REQUEST-API]]. This specification also relies on the Payment Request API usage of <dfn>Promise</dfn>, <dfn>internal slot</dfn>, <dfn>TypeError</dfn>, <dfn>JSON.stringify</dfn>, and <dfn>JSON-serializable</dfn>.</dd>
       <dt>Payment Method Identifiers</dt>
       <dd>The terms <dfn data-lt="payment method identifier|payment method identifiers">payment method identifier</dfn> is defined by the Payment Method
 	Identifier specification [[!METHOD-IDENTIFIERS]].</dd>
@@ -192,26 +191,6 @@
       clone</dfn>, <dfn>event handler</dfn>, <dfn>event handler
 	event type</dfn>, <dfn>trusted event</dfn>, and
       <dfn>user interaction task source</dfn> are defined by [[!HTML5]].</dd>
-      <dt>ECMA-262 6th Edition, The ECMAScript 2015 Language
-      Specification</dt>
-      <dd>
-          The terms <dfn data-cite=
-          "!ECMA-262-2015#sec-promise-objects">Promise</dfn>, <dfn data-cite=
-          "!ECMA-262-2015#sec-object-internal-methods-and-internal-slots">internal
-          slot</dfn>, <dfn data-cite=
-          "!ECMA-262-2015#sec-native-error-types-used-in-this-standard-typeerror">
-          TypeError</dfn>, and <dfn data-cite=
-          "!ECMA-262-2015#sec-json.stringify">JSON.stringify</dfn> are
-          defined by [[!ECMA-262-2015]].
-        <p>
-          The term <dfn data-lt=
-			"JSON-serialized|JSON-serializable">JSON-serialize</dfn> applied to
-          a given object means to run the algorithm specified by the original
-          value of the <a>JSON.stringify</a> function on the supplied object,
-          passing the supplied object as the sole argument, and return the
-          resulting string. This can throw an exception.
-        </p>
-      </dd>
       <dt>DOM4</dt>
       <dd>
         <p><dfn>DOMException</dfn> and the following DOMException

--- a/index.html
+++ b/index.html
@@ -758,7 +758,7 @@
     Request API, the user agent displays a list of matching origins
     for the user to make a selection. This specification includes a
     limited number of display requirements; most user experience
-    details are left to user agent implementers.</p>
+    details are left to implementers.</p>
     <section>
       <h3>Ordering of Payment Handlers</h3>
       <ul>
@@ -1189,7 +1189,7 @@
           Promise.</p>
           <p>If the Promise is rejected, the user agent MUST run
           the <dfn>payment app failure algorithm</dfn>. The exact
-          details of this algorithm are left to user agent
+          details of this algorithm are left to 
           implementers. Acceptable behaviors include,
           but are not limited to:</p>
           <ul>

--- a/index.html
+++ b/index.html
@@ -195,14 +195,14 @@
       <dd>The terms <dfn data-lt="payment method identifiers">payment method identifier</dfn> is defined by the Payment Method
 	Identifier specification [[!METHOD-IDENTIFIERS]].</dd>
       <dt>Basic Card Payment</dt>
-      <dd>The terms <dfn data-cite="!PAYMENT-REQUEST-API#method-id">basic-card</dfn>, <dfn data-cite="!PAYMENT-REQUEST-API#supportedNetworks">supportedNetworks</dfn>, and <dfn data-cite="!PAYMENT-REQUEST-API#supportedTypes">supportedTypes</dfn> are defined in [[!payment-method-basic-card]].</dd>
+      <dd>The terms <dfn data-cite="!PAYMENT-REQUEST-API#method-id">basic-card</dfn>, <dfn data-cite="!PAYMENT-REQUEST-API#supportedNetworks">supportedNetworks</dfn>, and <dfn data-cite="!PAYMENT-REQUEST-API#supportedTypes">supportedTypes</dfn> are defined in [[!PAYMENT-METHOD-BASIC-CARD]].</dd>
 
       <dt>HTML5</dt>
-      <dd>The terms <dfn>global object</dfn>,
-      <dfn>top-level browsing context</dfn>, <dfn>structured
-      clone</dfn>, <dfn>event handler</dfn>, <dfn>event handler
-	event type</dfn>, <dfn>trusted event</dfn>, and
-      <dfn>user interaction task source</dfn> are defined by [[!HTML5]].</dd>
+      <dd>The terms <dfn data-cite="!HTML5#global-object">global object</dfn>,
+      <dfn data-cite="!HTML5#top-level-browsing-context">top-level browsing context</dfn>, <dfn data-cite="!HTML5#structured-clone">structured
+      clone</dfn>, <dfn data-cite="!HTML5#event-handlers">event handler</dfn>, <dfn data-cite="!HTML5#event-handler-event-type">event handler
+	event type</dfn>, <dfn data-cite="!HTML5#concept-events-trusted">trusted event</dfn>, and
+      <dfn data-cite="!HTML5#user-interaction-task-source">user interaction task source</dfn> are defined by [[!HTML5]].</dd>
       <dt>RFC6454</dt>
       <dd>The term <dfn>origin</dfn> is defined in [[!RFC6454]].</dd>
       <dt>DOM</dt>
@@ -229,10 +229,10 @@
             </li>
           </ul>
       <dt>Secure Contexts</dt>
-      <dd>The terms <dfn>secure context</dfn> is defined by the
-      Secure Contexts specification [[!POWERFUL-FEATURES]].</dd>
+      <dd>The term <dfn data-cite="!secure-contexts#secure-context">secure context</dfn> is defined by the
+      Secure Contexts specification [[!SECURE-CONTEXTS]].</dd>
       <dt>Service Workers</dt>
-      <dd>The terms <code><dfn>service worker</dfn></code>, <code><dfn>ServiceWorkerRegistration</dfn></code>, <code><dfn>ServiceWorkerGlobalScope</dfn></code>, <dfn>handle functional event</dfn>, <dfn>extend lifetime promises</dfn>, and <dfn>scope URL</dfn> are defined in
+      <dd>The terms <dfn data-cite="!SERVICE-WORKERS#service-worker-concept">service worker</dfn>, <code><dfn data-cite="!SERVICE-WORKERS#service-worker-registration-concept">ServiceWorkerRegistration</dfn></code>, <code><dfn data-cite="!SERVICE-WORKERS#service-worker-global-scope">ServiceWorkerGlobalScope</dfn></code>, <dfn data-cite="!SERVICE-WORKERS#handle-functional-event-algorithm">handle functional event</dfn>, <dfn data-cite="!SERVICE-WORKERS#dfn-extend-lifetime-promises">extend lifetime promises</dfn>, and <dfn data-cite="!SERVICE-WORKERS#dfn-scope-url">scope URL</dfn> are defined in
       [[!SERVICE-WORKERS]].</dd>
     </dl>
   </section>
@@ -857,7 +857,7 @@
           This attribute a string that indicates the <a data-cite=
 							"!HTML5#origin">origin</a>
           of the <a>payee</a> web page. It MUST be formatted
-          according to the <a data-cite="!rfc6454#section-6.1">Unicode
+          according to the <a data-cite="!RFC6454#section-6.1">Unicode
             Serialization of an Origin</a> algorithm defined in
           section 6.1 of [[!RFC6454]].
         </p>
@@ -1449,8 +1449,7 @@ window.addEventListener("message", function(e) {
     <section>
       <h2>Secure Communications</h2>
       <ul>
-        <li>See <a href=
-        "https://www.w3.org/TR/service-workers/#security-considerations">
+        <li>See <a data-cite="SERVICE-WORKERS#security-considerations">
           Service Worker security considerations</a>
         </li>
         <li>Payment method security is outside the scope of this

--- a/index.html
+++ b/index.html
@@ -238,6 +238,11 @@
   </section>
   <section id="model">
     <h2>Overview of Handling Payment Requests</h2>
+
+    <p>A <dfn>Payment Handler</dfn> is a function registered by the
+      user with the user agent to
+      handle <a>PaymentRequestEvent</a>s.</p>
+    
     <p>In this document we envision the following flow:</p>
     <ol>
       <li>An origin requests permission from the user to handle
@@ -305,7 +310,7 @@
     authentication, user interaction, and so on.</p>
   </section>
   <section id="registration">
-    <h2><dfn>Payment Handler</dfn> Registration</h2>
+    <h2>Registration</h2>
     <section>
       <h2>Extension to the <code>ServiceWorkerRegistration</code> interface</h2>
       <p>This specification extends the <a>ServiceWorkerRegistration</a> interface.</p>
@@ -355,6 +360,7 @@
           Promise&lt;sequence&lt;DOMString&gt;&gt;  keys();
           Promise&lt;boolean&gt;           has(DOMString instrumentKey);
           Promise&lt;void&gt;              set(DOMString instrumentKey, PaymentInstrument details);
+          Promise&lt;void&gt;           clear();
       };
       </pre>
       <p>The <a>PaymentInstruments</a> interface represents a collection of
@@ -459,6 +465,23 @@
             <li> Return <var>p</var></li>
           </ol>
       </section>
+
+      <section>
+        <h2><dfn>clear()</dfn> method</h2>
+        <p>
+          When called, this method executes the following steps:</p>
+          <ol>
+            <li> Let <var>p</var> be a new promise.</li>
+            <li> Run the following steps in parallel:
+              <ol>
+		<li>Remove all <a>PaymentInstrument</a>s from
+		  the collection and resolve <var>p</var> with <b>true</b>.</li>
+              </ol>
+	    </li>
+            <li> Return <var>p</var></li>
+          </ol>
+	</section>
+
     </section>
     <section data-dfn-for="PaymentInstrument" data-link-for="PaymentInstrument">
       <h2><dfn>PaymentInstrument</dfn> dictionary</h2>
@@ -507,7 +530,9 @@
           Promise&lt;boolean&gt;       has(DOMString walletKey);
           Promise&lt;void&gt;          set(DOMString walletKey, PaymentWallet details);
       };
+          Promise&lt;void&gt;           clear();
       </pre>
+      
       <p>Where it appears, The <dfn>walletKey</dfn> argument is
       a unique identifier for the wallet.</p>
 
@@ -599,6 +624,22 @@
             </ol>
             <li> Return <var>p</var></li>
           </ol>
+      </section>
+
+      <section>
+        <h2><dfn>clear()</dfn> method</h2>
+        <p>
+          When called, this method executes the following steps:</p>
+        <ol>
+          <li> Let <var>p</var> be a new promise.</li>
+          <li> Run the following steps in parallel:
+            <ol>
+	      <li>Remove all <a>PaymentWallets</a> from
+		the collection and resolve <var>p</var> with <b>true</b>.</li>
+            </ol>
+	  </li>
+          <li> Return <var>p</var></li>
+        </ol>
       </section>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -901,8 +901,7 @@
         <p>
           This attribute is a string that indicates the <a data-cite=
 							"!HTML5#origin">origin</a>
-	  where a <a>PaymentRequest</a> was initialized.
-	  For example, when a <a>PaymentRequest</a> is initialized within an iframe, the value of this attribute is the origin of the iframe. The string MUST be formatted according to the "<a data-cite="!RFC6454#section-6.1">Unicode Serialization of an Origin</a>" algorithm defined in section 6.1 of [[!RFC6454]].
+	  where a <a>PaymentRequest</a> was initialized. When a <a>PaymentRequest</a> is initialized in the <a>topLevelOrigin</a>, the attributes have the same value, otherwise the attributes have different values. For example, when a <a>PaymentRequest</a> is initialized within an iframe from an origin other than <a>topLevelOrigin</a>, the value of this attribute is the origin of the iframe. The string MUST be formatted according to the "<a data-cite="!RFC6454#section-6.1">Unicode Serialization of an Origin</a>" algorithm defined in section 6.1 of [[!RFC6454]].
         </p>
       </section>
       <section>

--- a/index.html
+++ b/index.html
@@ -61,6 +61,16 @@
                     ],
                     status:   "WD"
                 },
+                "BASIC-CARD": {
+                    title:    "Basic Card Payment",
+                    href:     "https://www.w3.org/TR/payment-method-basic-card/",
+                    authors:  [
+                        "Adrian Bateman",
+                        "Zach Koch",
+                        "Roy McElmurray"
+                    ],
+                    status:   "WD"
+                },
                 "METHOD-IDENTIFIERS": {
                     title:    "Payment Method Identifiers",
                     href:     "https://www.w3.org/TR/payment-method-id/",
@@ -115,7 +125,7 @@
     published the Payment Request API [[!PAYMENT-REQUEST-API]] as a
     standard way to initiate payment requests from E-Commerce Web
     sites and applications.</p>
-    <p>A <dfn id="payment-app">payment app</dfn> is a Web
+    <p>A <dfn>payment app</dfn> is a Web
     application that manages payment requests on behalf of the user
     by supporting one or more payment methods. To enable a Web
     application to handle payment requests, this specification
@@ -161,35 +171,37 @@
     </dl>
   </section>
   <section id="dependencies">
-    <h3>Dependencies</h3>
+    <h2>Dependencies</h2>
     <p>This specification relies on several other underlying
     specifications.</p>
     <dl>
       <dt>Payment Request API</dt>
-      <dd>The terms <dfn data-lt="payment method|payment methods">payment method</dfn>, <dfn>PaymentRequest</dfn>,
-      <dfn>PaymentResponse</dfn>, and <dfn>user accepts the payment
+      <dd>The terms <dfn>payment method</dfn>, <dfn>PaymentRequest</dfn>,
+      <dfn>PaymentResponse</dfn>, <dfn>supportedMethods</dfn>, <dfn>paymentDetailsModifier</dfn>, <dfn>paymentDetails</dfn>, <dfn>PaymentMethodData</dfn>, <dfn>ID</dfn>, and <dfn>user accepts the payment
       request algorithm</dfn> are defined by the Payment Request
       API specification [[!PAYMENT-REQUEST-API]].</dd>
       <dt>Payment Method Identifiers</dt>
       <dd>The terms <dfn data-lt="payment method identifier|payment method identifiers">payment method identifier</dfn> is defined by the Payment Method
-      Identifier specification [[!METHOD-IDENTIFIERS]].</dd>
+	Identifier specification [[!METHOD-IDENTIFIERS]].</dd>
+      <dt>Basic Card Payment</dt>
+      <dd>The terms <dfn>basic-card</dfn>, <dfn>supportedNetworks</dfn>, and <dfn>supportedTypes</dfn> are defined in [[BASIC-CARD]].</dd>
+
       <dt>HTML5</dt>
-      <dd>The terms <dfn>global object</dfn>,<dfn>origin</dfn>,
-      <dfn>queue a task</dfn>, <dfn>browsing context</dfn>,
+      <dd>The terms <dfn>global object</dfn>, <dfn>origin</dfn>,
       <dfn>top-level browsing context</dfn>, <dfn>structured
       clone</dfn>, <dfn>event handler</dfn>, <dfn>event handler
-      event type</dfn>, <dfn>trusted event</dfn>, and <dfn>current
-      settings object</dfn> are defined by [[!HTML5]].</dd>
+	event type</dfn>, <dfn>trusted event</dfn>, and
+      <dfn>user interaction task source</dfn> are defined by [[!HTML5]].</dd>
       <dt>ECMA-262 6th Edition, The ECMAScript 2015 Language
       Specification</dt>
       <dd>
           The terms <dfn data-cite=
           "!ECMA-262-2015#sec-promise-objects">Promise</dfn>, <dfn data-cite=
           "!ECMA-262-2015#sec-object-internal-methods-and-internal-slots">internal
-          slot</dfn>, <code><dfn data-cite=
+          slot</dfn>, <dfn data-cite=
           "!ECMA-262-2015#sec-native-error-types-used-in-this-standard-typeerror">
-          TypeError</dfn></code>, and <code><dfn data-cite=
-          "!ECMA-262-2015#sec-json.stringify">JSON.stringify</dfn></code> are
+          TypeError</dfn>, and <dfn data-cite=
+          "!ECMA-262-2015#sec-json.stringify">JSON.stringify</dfn> are
           defined by [[!ECMA-262-2015]].
         <p>
           The term <dfn data-lt=
@@ -210,28 +222,29 @@
             <th>Message (optional)</th>
           </tr>
           <tr>
-            <td><code><dfn>AbortError</dfn></code></td>
+            <td><dfn>AbortError</dfn></td>
             <td>The operation was aborted</td>
           </tr>
           <tr>
-            <td><code><dfn>InvalidStateError</dfn></code></td>
+            <td><dfn>InvalidStateError</dfn></td>
             <td>The object is in an invalid state</td>
           </tr>
           <tr>
-            <td><code><dfn>NotFoundError</dfn></code></td>
+            <td><dfn>NotFoundError</dfn></td>
             <td>The object can not be found here.</td>
           </tr>
           <tr>
-            <td><code><dfn>SecurityError</dfn></code></td>
+            <td><dfn>SecurityError</dfn></td>
             <td>The operation is only supported in a secure
             context</td>
           </tr>
           <tr>
-            <td><code><dfn>OperationError</dfn></code></td>
+            <td><dfn>OperationError</dfn></td>
             <td>The operation failed for an operation-specific
             reason.</td>
           </tr>
         </table>
+	<p>The term <dfn data-cite= "!DOM4#firing-events">fires</dfn> (an event) is defined in [[!DOM4]].
       </dd>
       <dt>WebIDL</dt>
       <dd>
@@ -243,7 +256,7 @@
             <th>Message (optional)</th>
           </tr>
           <tr>
-            <td><code><dfn>NotAllowedError</dfn></code></td>
+            <td><dfn>NotAllowedError</dfn></td>
             <td>The request is not allowed by the user agent or the
             platform in the current context.</td>
           </tr>
@@ -252,23 +265,8 @@
       <dt>Secure Contexts</dt>
       <dd>The terms <dfn>secure context</dfn> is defined by the
       Secure Contexts specification [[!POWERFUL-FEATURES]].</dd>
-      <dt>URL</dt>
-      <dd>The <dfn>URL</dfn> concept and <dfn>URL parser</dfn> are
-      defined in [[!WHATWG-URL]].</dd>
-      <dt>Fetch</dt>
-      <dd>The terms <dfn>Fetch</dfn>, <dfn>Request</dfn>,
-      <dfn data-lt="body">Request Body</dfn>, <dfn data-lt=
-      "method">Request Method</dfn>, <dfn>Header List</dfn>,
-      <dfn>Response</dfn>, <dfn>Context</dfn> and <dfn>Network
-      Error</dfn> are defined in [[!FETCH]].</dd>
       <dt>Service Workers</dt>
-      <dd>The terms <dfn data-lt=
-      "service worker|service workers">service worker</dfn>
-      <dfn>service worker registration</dfn>, <dfn>active
-      worker</dfn>, <dfn>installing worker</dfn>, <dfn>waiting
-      worker</dfn>, <dfn>handle functional event</dfn>, <dfn>extend
-      lifetime promises</dfn>, and <dfn data-lt=
-      "scope url|scope urls">scope URL</dfn> are defined in
+      <dd>The terms <dfn>service worker</dfn>, <dfn>ServiceWorkerRegistration</dfn>, <dfn>ServiceWorkerGlobalScope</dfn>, <dfn>handle functional event</dfn>, <dfn>extend lifetime promises</dfn>, and <dfn>scope URL</dfn> are defined in
       [[!SERVICE-WORKERS]].</dd>
     </dl>
   </section>
@@ -309,8 +307,9 @@
       displaying and grouping Instruments according to information
       (labels and icons) provided at registration or otherwise
       available from the Web app.</li>
-      <li>When the user (the <dfn>payer</dfn>) selects an Instrument, the user agent fires the
-      <a>PaymentRequestEvent</a> in the service worker whose registration
+      <li>When the user (the <dfn>payer</dfn>) selects an Instrument, the user agent <a>fires</a> an event (cf. the <a>user interaction task source</a>)
+	using the <a>PaymentRequestEvent</a> interface
+	in the service worker whose registration
       included the payment handler that provided that Instrument. The
       <a>PaymentRequestEvent</a> includes some information from the
       PaymentRequest (defined in [[!PAYMENT-REQUEST-API]]) as well
@@ -343,37 +342,35 @@
   <section id="registration">
     <h2><dfn>Payment Handler</dfn> Registration</h2>
     <section>
-      <h3>Extensions to the ServiceWorkerRegistration interface</h3>
-      <p>The Service Worker specification defines a
-      <dfn>ServiceWorkerRegistration</dfn> interface
-      [[!SERVICE-WORKERS]], which this specification extends.</p>
-      <pre id="service-worker-registration-idl" class="idl">
+      <h2>Extension to the ServiceWorkerRegistration interface</h2>
+      <p>This specification extends the <a>ServiceWorkerRegistration</a> interface.</p>
+      <pre class="idl">
         partial interface ServiceWorkerRegistration {
           readonly attribute PaymentManager paymentManager;
         };
       </pre>
     </section>
-    <section data-dfn-for="PaymentManager">
-      <h3><dfn>PaymentManager</dfn> interface</h3>
-      <pre id="payment-manager-idl" class="idl">
+    <section data-dfn-for="PaymentManager" data-link-for="PaymentManager">
+      <h2><dfn>PaymentManager</dfn> interface</h2>
+      <pre class="idl">
       interface PaymentManager {
         [SameObject] readonly attribute PaymentInstruments instruments;
         [SameObject] readonly attribute PaymentWallets wallets;
       };
       </pre>
-      <dl>
-        <dt><dfn>instruments</dfn> attribute</dt>
-        <dd>
-          This attribute allows manipulation of payment instruments
+      <section>
+	<h2><dfn>instruments</dfn> attribute</h2>
+        <p>This attribute allows manipulation of payment instruments
           associated with a payment handler. To be presented to the
           user as part of the payment request flow, payment
           handlers must have at least one registered payment
           Instrument, and that Instrument needs to match the payment
           methods and required capabilities specified by the
-          payment request.
-        </dd>
-        <dt><dfn>wallets</dfn> attribute</dt>
-        <dd>This attribute allows payment handlers to group payment
+          payment request.</p>
+      </section>
+      <section>
+        <h2><dfn>wallets</dfn> attribute</h2>
+        <p>This attribute allows payment handlers to group payment
         instruments together and provide a name and icon for such a
         group (e.g., to group together "business account" payment
         instruments separately from "personal account" payment
@@ -381,53 +378,60 @@
         handlers is completely optional. If payment handlers use
         this grouping mechanism, then matching payment instruments that
         do not appear in any groups should still be presented to
-        users by the browser for selection.</dd>
-      </dl>
+          users by the browser for selection.</p>
+      </section>
     </section>
-    <section data-dfn-for="PaymentInstruments">
-      <h3><dfn>PaymentInstruments</dfn> interface</h3>
-      <pre id="payment-instruments-idl" class="idl">
+    <section data-dfn-for="PaymentInstruments" data-link-for="PaymentInstruments">
+      <h2><dfn>PaymentInstruments</dfn> interface</h2>
+      <pre class="idl">
       interface PaymentInstruments {
-          Promise&lt;boolean&gt;              delete(DOMString instrumentKey);
+          Promise&lt;boolean&gt;           delete(DOMString instrumentKey);
           Promise&lt;PaymentInstrument&gt; get(DOMString instrumentKey);
           Promise&lt;sequence&lt;DOMString&gt;&gt;  keys();
-          Promise&lt;boolean&gt;              has(DOMString instrumentKey);
-          Promise&lt;void&gt;                 set(DOMString instrumentKey,
-                                              PaymentInstrument details);
+          Promise&lt;boolean&gt;           has(DOMString instrumentKey);
+          Promise&lt;void&gt;              set(DOMString instrumentKey, PaymentInstrument details);
       };
       </pre>
       <p>The <a>PaymentInstruments</a> interface represents a collection of
       payment instruments, each uniquely identified by an <dfn>instrumentKey</dfn>.
       The <a>instrumentKey</a> identifier will be passed to the
       payment handler to indicate the <a>PaymentInstrument</a>
-      selected by the user.</p>
-      <dl>
+	selected by the user.</p>
 
-        <dt><dfn>delete</dfn> method</dt>
-        <dd>
-          When called, this method executes the following steps:
+      
+      <pre class="example highlight" title="Removing all instruments">
+        return paymentManager.instruments.keys().then((keys) =&gt; {
+          Promise.all(keys.map(paymentManager.instruments.delete(key)))
+        });
+      </pre>
+
+      <section>
+        <h2><dfn>delete</dfn> method</h2>
+        <p>
+          When called, this method executes the following steps:</p>
           <ol>
             <li> Let <var>p</var> be a new promise.</li>
-            <li> Run the following steps in parallel:</li>
+            <li> Run the following steps in parallel:
             <ol>
               <li> If the collection contains a <a>PaymentInstrument</a>
-              with a matching <code>instrumentKey</code>, remove it from
+              with a matching <a>instrumentKey</a>, remove it from
               the collection and resolve <var>p</var> with <b>true</b>.</li>
               <li> Otherwise, resolve <var>p</var> with <b>false</b>.</li>
             </ol>
             <li> Return <var>p</var></li>
           </ol>
-        </dd>
+	</section>
 
-        <dt><dfn>get</dfn> method</dt>
-        <dd>
-          When called, this method executes the following steps:
+      <section>
+        <h2><dfn>get</dfn> method</h2>
+        <p>
+          When called, this method executes the following steps:</p>
           <ol>
             <li> Let <var>p</var> be a new promise.</li>
-            <li> Run the following steps in parallel:</li>
+            <li> Run the following steps in parallel:
             <ol>
               <li> If the collection contains a <a>PaymentInstrument</a>
-              with a matching <code>instrumentKey</code>, resolve <var>p</var>
+              with a matching <a>instrumentKey</a>, resolve <var>p</var>
               with that <a>PaymentInstrument</a>.
               <li> Otherwise, reject <var>p</var> with a
               <a>DOMException</a> whose value is
@@ -435,71 +439,65 @@
             </ol>
             <li> Return <var>p</var></li>
           </ol>
-        </dd>
+      </section>
 
-        <dt><dfn>keys</dfn> method</dt>
-        <dd>
-          When called, this method executes the following steps:
+      <section>
+        <h2><dfn>keys</dfn> method</h2>
+        <p>
+          When called, this method executes the following steps:</p>
           <ol>
             <li> Let <var>p</var> be a new promise.</li>
-            <li> Run the following steps in parallel:</li>
+            <li> Run the following steps in parallel:
             <ol>
-              <li>Resolve <var>p</var> with a sequence that contains all
-              the <code>instrumentKey</code>s for the <a>PaymentInstrument</a>s
+              <li>Resolve <var>p</var> with a <dfn>Sequence</dfn> that contains all
+              the <a>instrumentKey</a>s for the <a>PaymentInstrument</a>s
               contained in the collection.
             </ol>
             <li> Return <var>p</var></li>
           </ol>
-        </dd>
+      </section>
 
-        <dt><dfn>has</dfn> method</dt>
-        <dd>
-          When called, this method executes the following steps:
+      <section>
+        <h2><dfn>has</dfn> method</h2>
+        <p>
+          When called, this method executes the following steps:</p>
           <ol>
             <li> Let <var>p</var> be a new promise.</li>
-            <li> Run the following steps in parallel:</li>
+            <li> Run the following steps in parallel:
             <ol>
               <li> If the collection contains a <a>PaymentInstrument</a>
-              with a matching <code>instrumentKey</code>, resolve <var>p</var>
+              with a matching <a>instrumentKey</a>, resolve <var>p</var>
               with <b>true</b>.</li>
               <li> Otherwise, resolve <var>p</var> with <b>false</b>.</li>
             </ol>
             <li> Return <var>p</var></li>
           </ol>
-        </dd>
+      </section>
 
-        <dt><dfn>set</dfn> method</dt>
-        <dd>
-          When called, this method executes the following steps:
+      <section>
+        <h2><dfn>set</dfn> method</h2>
+        <p>
+          When called, this method executes the following steps:</p>
           <ol>
             <li> Let <var>p</var> be a new promise.</li>
-            <li> Run the following steps in parallel:</li>
+            <li> Run the following steps in parallel:
             <ol>
               <li> If the collection contains a <a>PaymentInstrument</a>
-              with a matching <code>instrumentKey</code>, replace it with
-              the <a>PaymentInstrument</a> in <code>details</code>.
+              with a matching <a>instrumentKey</a>, replace it with
+              the <a>PaymentInstrument</a> in <dfn>details</dfn>.
               <li> Otherwise, <a>PaymentInstrument</a>
-              insert the <a>PaymentInstrument</a> in <code>details</code>
+              insert the <a>PaymentInstrument</a> in <a>details</a>
               as a new member of the collection and associate it with the
-              key <code>instrumentKey</code>.
+              key <a>instrumentKey</a>.
               <li> Resolve <var>p</var>.</li>
             </ol>
             <li> Return <var>p</var></li>
           </ol>
-        </dd>
-      </dl>
-
-      <pre class="example highlight" title="Removing all instruments">
-        return paymentManager.instruments.keys().then((keys) =&gt; {
-          Promise.all(keys.map(paymentManager.instruments.delete(key)))
-        });
-      </pre>
-
-
+      </section>
     </section>
-    <section data-dfn-for="PaymentInstrument">
-      <h3><dfn>PaymentInstrument</dfn> dictionary</h3>
-      <pre id="payment-instrument-idl" class="idl">
+    <section data-dfn-for="PaymentInstrument" data-link-for="PaymentInstrument">
+      <h2><dfn>PaymentInstrument</dfn> dictionary</h2>
+      <pre class="idl">
       dictionary PaymentInstrument {
         required DOMString name;
         sequence&lt;ImageObjects&gt; icons;
@@ -508,73 +506,73 @@
       };
       </pre>
       <dl>
-        <dt><dfn id="payment-instrument-name">name</dfn> member</dt>
-        <dd>The <code>name</code> member is a string that
-        represents the label for this payment Instrument as it is
+        <dt><dfn>name</dfn> member</dt>
+        <dd>The <a>name</a> member is a string that
+        represents the label for this PaymentInstrument as it is
         usually displayed to the user.</dd>
         <dt><dfn>icons</dfn> member</dt>
-        <dd>The <code>icons</code> member is an array of image
+        <dd>The <a>icons</a> member is an array of image
         objects that can serve as iconic representations of the
         payment Instrument when presented to the user for
         selection.</dd>
-        <dt><dfn id="payment-instrument-enabled-methods">enabledMethods</dfn> member</dt>
+        <dt><dfn>enabledMethods</dfn> member</dt>
         <dd>
-          The <code>enabledMethods</code>
+          The <a>enabledMethods</a>
           member lists the <a>payment method identifiers</a> of the
           payment methods enabled by this Instrument.
         </dd>
-        <dt><dfn id="payment-instrument-capabilities">capabilities</dfn> member</dt>
-        <dd>The <code>capabilities</code>
+        <dt><dfn>capabilities</dfn> member</dt>
+        <dd>The <a>capabilities</a>
         member contains a list of payment-method-specific
         capabilities that this payment handler is capable of
         supporting for this Instrument. For example, for the
-        <code>basic-card</code> payment method, this object will
+        <a>basic-card</a> payment method, this object will
         consist of an object with two fields: one for
-        <code>supportedNetworks</code>, and another for
-        <code>supportedTypes</code>.</dd>
+        <a>supportedNetworks</a>, and another for
+        <a>supportedTypes</a>.</dd>
       </dl>
     </section>
-    <section data-dfn-for="PaymentWallets">
-      <h3><dfn>PaymentWallets</dfn> interface</h3>
-      <pre id="payment-wallets-idl" class="idl">
+    <section data-dfn-for="PaymentWallets" data-link-for="PaymentWallets">
+      <h2><dfn>PaymentWallets</dfn> interface</h2>
+      <pre class="idl">
       interface PaymentWallets {
-          Promise&lt;boolean&gt;              delete(DOMString walletKey);
+          Promise&lt;boolean&gt;       delete(DOMString walletKey);
           Promise&lt;PaymentWallet&gt; get(DOMString walletKey);
           Promise&lt;sequence&lt;DOMString&gt;&gt;  keys();
-          Promise&lt;boolean&gt;              has(DOMString walletKey);
-          Promise&lt;void&gt;                 set(DOMString walletKey,
-                                              PaymentWallet details);
+          Promise&lt;boolean&gt;       has(DOMString walletKey);
+          Promise&lt;void&gt;          set(DOMString walletKey, PaymentWallet details);
       };
       </pre>
-      <p>Where it appears, The <code>walletKey</code> parameter is
+      <p>Where it appears, The <dfn>walletKey</dfn> parameter is
       a unique identifier for the wallet.</p>
-      <dl>
 
-        <dt><dfn>delete</dfn> method</dt>
-        <dd>
-          When called, this method executes the following steps:
+      <section>
+        <h2><dfn>delete</dfn> method</h2>
+        <p>
+          When called, this method executes the following steps:</p>
           <ol>
             <li> Let <var>p</var> be a new promise.</li>
-            <li> Run the following steps in parallel:</li>
+            <li> Run the following steps in parallel:
             <ol>
               <li> If the collection contains a <a>PaymentWallet</a>
-              with a matching <code>walletKey</code>, remove it from
+              with a matching <a>walletKey</a>, remove it from
               the collection and resolve <var>p</var> with <b>true</b>.</li>
               <li> Otherwise, resolve <var>p</var> with <b>false</b>.</li>
             </ol>
             <li> Return <var>p</var></li>
           </ol>
-        </dd>
+      </section>
 
-        <dt><dfn>get</dfn> method</dt>
-        <dd>
-          When called, this method executes the following steps:
+      <section>
+        <h2><dfn>get</dfn> method</h2>
+        <p>
+          When called, this method executes the following steps:</p>
           <ol>
             <li> Let <var>p</var> be a new promise.</li>
-            <li> Run the following steps in parallel:</li>
+            <li> Run the following steps in parallel:
             <ol>
               <li> If the collection contains a <a>PaymentWallet</a>
-              with a matching <code>walletKey</code>, resolve <var>p</var>
+              with a matching <a>walletKey</a>, resolve <var>p</var>
               with that <a>PaymentWallet</a>.
               <li> Otherwise, reject <var>p</var> with a
               <a>DOMException</a> whose value is
@@ -582,65 +580,66 @@
             </ol>
             <li> Return <var>p</var></li>
           </ol>
-        </dd>
+      </section>
 
-        <dt><dfn>keys</dfn> method</dt>
-        <dd>
-          When called, this method executes the following steps:
+      <section>
+        <h2><dfn>keys</dfn> method</h2>
+        <p>
+          When called, this method executes the following steps:</p>
           <ol>
             <li> Let <var>p</var> be a new promise.</li>
-            <li> Run the following steps in parallel:</li>
+            <li> Run the following steps in parallel:
             <ol>
               <li>Resolve <var>p</var> with a sequence that contains all
-              the <code>walletKey</code>s for the <a>PaymentWallet</a>s
+              the <a>walletKey</a>s for the <a>PaymentWallet</a>s
               contained in the collection.
             </ol>
             <li> Return <var>p</var></li>
           </ol>
-        </dd>
+      </section>
 
-        <dt><dfn>has</dfn> method</dt>
-        <dd>
-          When called, this method executes the following steps:
+      <section>
+        <h2><dfn>has</dfn> method</h2>
+        <p>
+          When called, this method executes the following steps:</p>
           <ol>
             <li> Let <var>p</var> be a new promise.</li>
-            <li> Run the following steps in parallel:</li>
+            <li> Run the following steps in parallel:
             <ol>
               <li> If the collection contains a <a>PaymentWallet</a>
-              with a matching <code>walletKey</code>, resolve <var>p</var>
+              with a matching <a>walletKey</a>, resolve <var>p</var>
               with <b>true</b>.</li>
               <li> Otherwise, resolve <var>p</var> with <b>false</b>.</li>
             </ol>
             <li> Return <var>p</var></li>
           </ol>
-        </dd>
+      </section>
 
-        <dt><dfn>set</dfn> method</dt>
-        <dd>
-          When called, this method executes the following steps:
+      <section>
+        <h2><dfn>set</dfn> method</h2>
+        <p>
+          When called, this method executes the following steps:</p>
           <ol>
             <li> Let <var>p</var> be a new promise.</li>
-            <li> Run the following steps in parallel:</li>
+            <li> Run the following steps in parallel:
             <ol>
               <li> If the collection contains a <a>PaymentWallet</a>
-              with a matching <code>walletKey</code>, replace it with
-              the <a>PaymentWallet</a> in <code>details</code>.
+              with a matching <a>walletKey</a>, replace it with
+              the <a>PaymentWallet</a> in <a>details</a>.
               <li> Otherwise, <a>PaymentWallet</a>
-              insert the <a>PaymentWallet</a> in <code>details</code>
+              insert the <a>PaymentWallet</a> in <a>details</a>
               as a new member of the collection and associate it with the
-              key <code>walletKey</code>.
+              key <a>walletKey</a>.
               <li> Resolve <var>p</var>.</li>
             </ol>
             <li> Return <var>p</var></li>
           </ol>
-        </dd>
-
-      </dl>
-
+      </section>
     </section>
-    <section data-dfn-for="PaymentWallet">
-      <h3><dfn>PaymentWallet</dfn> dictionary</h3>
-      <pre id="payment-wallet-idl" class="idl">
+
+    <section data-dfn-for="PaymentWallet" data-link-for="PaymentWallet">
+      <h2><dfn>PaymentWallet</dfn> dictionary</h2>
+      <pre class="idl">
       dictionary PaymentWallet {
           required DOMString name;
           sequence&lt;ImageObject&gt; icons;
@@ -648,18 +647,18 @@
       };
       </pre>
       <dl>
-        <dt><dfn id="payment-wallet-name">name</dfn> member</dt>
-        <dd>The <code>name</code> member is a string that
+        <dt><dfn>name</dfn> member</dt>
+        <dd>The <a>name</a> member is a string that
         represents the label for this wallet as it is usually
         displayed to the user.</dd>
-        <dt><dfn id="payment-wallet-icons">icons</dfn> member</dt>
-        <dd>The <code>icons</code> member is an array of image
+        <dt><dfn>icons</dfn> member</dt>
+        <dd>The <a>icons</a> member is an array of image
         objects that can serve as iconic representations of the
         wallet when presented to the user for selection.</dd>
-        <dt><dfn id="payment-wallet-instrument-keys">instrumentKeys</dfn> member</dt>
-        <dd>The <code>instrumentKeys</code> member is a
-        list of <code>instrumentKey</code>s from
-        <code>PaymentManager.instruments</code>,
+        <dt><dfn>instrumentKeys</dfn> member</dt>
+        <dd>The <a>instrumentKeys</a> member is a
+        list of <a>instrumentKey</a>s from
+        <a>PaymentManager</a>.<a data-lt="PaymentManager.instruments">instruments</a>,
         indicating which <a>PaymentInstrument</a> objects are associated
         with this <a>Wallet</a>, and should be displayed as being "contained in"
         the wallet. While it is not generally good practice, there is no
@@ -669,7 +668,7 @@
       </dl>
     </section>
     <section id="register-example">
-      <h3>Registration Example</h3>
+      <h2>Registration Example</h2>
       <p>The following example shows how to register a payment
       handler:</p>
       <p class="issue" title="Issue 94 - Permission"><a href=
@@ -677,7 +676,7 @@
       Issue 94</a>. The means for code requesting permission to handle
       payments is not yet defined. The code below is based on one
       potential model (a <code>requestPermission()</code> method on the
-      <code>PaymentManager</code>),
+      <a>PaymentManager</a>),
       but this is likely to change.
       </p>
       <pre class="example highlight" title=
@@ -777,7 +776,7 @@
     limited number of display requirements; most user experience
     details are left to implementers.</p>
     <section>
-      <h3>Ordering of Payment Handlers</h3>
+      <h2>Ordering of Payment Handlers</h2>
       <ul>
         <li>The user agent <span class='rfc2119'>MUST</span> favor
         user-side order preferences (based on user configuration or
@@ -807,7 +806,7 @@
       </ul>
     </section>
     <section>
-      <h3>Display of Instruments</h3>
+      <h2>Display of Instruments</h2>
       <p>The user agent <span class='rfc2119'>MUST</span> enable
       the user to select any displayed Instrument.</p>
       <ul>
@@ -832,7 +831,7 @@
       responsibility to display instruments to the user.</p>
     </section>
     <section>
-      <h3>Grouping of Instruments</h3>
+      <h2>Grouping of Instruments</h2>
       <p>At times, the same origin may wish to group instruments with
       greater flexibility and granularity than merely "by origin."
       These use cases include:</p>
@@ -843,7 +842,7 @@
         business wallet vs personal wallet)</li>
         <li>Multiple instruments held with a single provider</li>
       </ul>
-      <p>A <dfn id="wallet">Wallet</dfn> is a grouping of Instruments
+      <p>A <dfn>Wallet</dfn> is a grouping of Instruments
       for display purposes.</p>
       <p>To enable developers to build payment apps in a variety of
       ways, we decouple the registration (and subsequent display)
@@ -852,7 +851,7 @@
       for communicating the user's selection in the event.</p>
     </section>
     <section>
-      <h3>Selection of Instruments</h3>
+      <h2>Selection of Instruments</h2>
       <p>Users agents may wish to enable the user to select
       individual displayed Instruments. The payment handler would
       receive information about the selected Instrument and could take
@@ -870,12 +869,12 @@
     </section>
   </section>
   <section id="invocation">
-    <h2>Payment Handler Invocation, Display and Response</h2>
+    <h2>Invocation</h2>
     <p>Once the user has selected an Instrument, the user agent fires a
     <a>PaymentRequestEvent</a> with a <a>PaymentAppRequest</a>, and
     uses the subsequent <a>PaymentAppResponse</a> to create a
     PaymentReponse for [[!PAYMENT-REQUEST-API]].</p>
-    <section data-dfn-for="PaymentAppRequest">
+    <section data-dfn-for="PaymentAppRequest" data-link-for="PaymentAppRequest">
       <h2><dfn>PaymentAppRequest</dfn> interface</h2>
       <pre class="idl">
       interface PaymentAppRequest {
@@ -887,63 +886,73 @@
         readonly attribute DOMString instrumentId;
       };
       </pre>
-      <dl>
-        <dt><dfn>origin<dfn> attribute</dt>
-        <dd>
+      <section>
+	<h2><dfn>origin</dfn> attribute</h2>
+        <p>
           This attribute a string that indicates the <a data-cite=
-          "!HTML5#origin">origin</a>
+							"!HTML5#origin">origin</a>
           of the <a>payee</a> web page. It MUST be formatted
           according to the "<a href=
-          "https://tools.ietf.org/html/rfc6454#section-6.1">Unicode
-          Serialization of an Origin</a>" algorithm defined in
+			       "https://tools.ietf.org/html/rfc6454#section-6.1">Unicode
+            Serialization of an Origin</a>" algorithm defined in
           section 6.1 of [[!RFC6454]].
-        </dd>
-        <dt><dfn>id</dfn> attribute</dt>
-        <dd>
-          When getting, the <code>id</code> attribute returns the
-          <code>[[\details]].id</code> from the <a>PaymentRequest</a> that
-          corresponds to this <code>PaymentAppRequest</code>.
-        </dd>
-        <dt><dfn>methodData</dfn> attribute</dt>
-        <dd>
-          This attribute contains <code>PaymentMethodData</code>
+        </p>
+      </section>
+      <section>
+	<h2><dfn>id</dfn> attribute</h2>
+        <p>
+          When getting, the <a>id</a> attribute returns the
+          [[\details]].<a>id</a> from the <a>PaymentRequest</a> that
+          corresponds to this <a>PaymentAppRequest</a>.
+        </p>
+      </section>
+      <section>
+	<h2><dfn>methodData</dfn> attribute</h2>
+        <p>
+          This attribute contains <a>PaymentMethodData</a>
           dictionaries containing the <a>payment method
-          identifiers</a> for the <a>payment methods</a> that the
+            identifiers</a> for the <a>payment method</a>(s) that the
           web site accepts and any associated <a>payment method</a>
           specific data. It is populated from the
-          <a>PaymentRequest</a> using the <a>Method Data Population
-          Algorithm</a> defined below.
-        </dd>
-        <dt><dfn>total</dfn> attribute</dt>
-        <dd>
-          This attribute indicates the total amount being requested
-          for payment. It is initialized with a <a>structured
-          clone</a> of the <code>total</code> field of the
-          <code>PaymentDetails</code> provided when the
+          <a>PaymentRequest</a> using the <a>MethodData Population
+            Algorithm</a> defined below.
+        </p>
+      </section>
+      <section>
+	<h2><dfn>total</dfn> attribute</h2>
+	<p>
+	  This attribute indicates the total amount being requested
+	  for payment. It is initialized with a <a>structured
+	    clone</a> of the <a>total</a> field of the
+          <a>PaymentDetails</a> provided when the
           corresponding <a>PaymentRequest</a> object was
           instantiated.
-        </dd>
-        <dt><dfn>modifiers</dfn> attribute</dt>
-        <dd>
-          This sequence of <code>PaymentDetailsModifier</code>
+        </p>
+      </section>
+      <section>
+	<h2><dfn>modifiers</dfn> attribute</h2>
+        <p>
+          This sequence of <a>PaymentDetailsModifier</a>
           dictionaries contains modifiers for particular payment
           method identifiers (e.g., if the payment amount or
           currency type varies based on a per-payment-method
           basis). It is populated from the <a>PaymentRequest</a>
           using the <a>Modifiers Population Algorithm</a> defined
           below.
-        </dd>
-        <dt><dfn>instrumentId</dfn> attribute</dt>
-        <dd>
+        </p>
+      </section>
+      <section>
+	<h2><dfn>instrumentId</dfn> attribute</h2>
+        <p>
           This attribute indicates the <a>PaymentInstrument</a>
           selected by the user. It corresponds to the
-          <code>id</code> field provided during registration.
-        </dd>
-      </dl>
+          <a>id</a> field provided during registration.
+        </p>
+      </section>
 
       <section>
-        <h3><dfn>Method Data Population Algorithm</dfn></h3>
-        <p>To initialize the value of the <code>methodData</code>,
+        <h2><dfn>MethodData Population Algorithm</dfn></h2>
+        <p>To initialize the value of the <a>methodData</a>,
         the user agent MUST perform the following steps or their
         equivalent:</p>
         <ol>
@@ -951,15 +960,15 @@
           set.</li>
           <li>For each <a>PaymentInstrument</a> <var>instrument</var> in
           the <a>payment handler</a>'s
-          <code>PaymentManager.instruments</code>, add all entries
-          in <var>instrument</var>.<code>enabledMethods</code> to <var>
+          <a>PaymentManager</a>.<a data-lt="PaymentManager.instruments">instruments</a>, add all entries
+          in <var>instrument</var>.<a data-lt="PaymentInstrument.enabledMethods">enabledMethods</a> to <var>
             registeredMethods</var>.
           </li>
-          <li>Create a new empty <code>Sequence</code>.</li>
+          <li>Create a new empty <a>Sequence</a>.</li>
           <li>Set <var>dataList</var> to the newly created
-          <code>Sequence</code>.</li>
+          <a>Sequence</a>.</li>
           <li>For each item in
-          <code>PaymentRequest</code>@<var>[[\methodData]]</var> in
+          <a>PaymentRequest</a>@<var>[[\methodData]]</var> in
           the corresponding payment request, perform the following
           steps:
             <ol>
@@ -967,33 +976,33 @@
               consideration.</li>
               <li>Set <var>commonMethods</var> to the set
               intersection of
-              <var>inData</var>.<code>supportedMethods</code> and
+              <var>inData</var>.<a>supportedMethods</a> and
               <var>registeredMethods</var>.</li>
               <li>If <var>commonMethods</var> is empty, skip the
               remaining substeps and move on to the next item (if
               any).</li>
-              <li>Create a new <code>PaymentMethodData</code>
+              <li>Create a new <a>PaymentMethodData</a>
               object.</li>
               <li>Set <var>outData</var> to the newly created
-              <code>PaymentMethodData</code>.</li>
+              <a>PaymentMethodData</a>.</li>
               <li>Set
-              <var>outData</var>.<code>supportedMethods</code> to a
+              <var>outData</var>.<a>supportedMethods</a> to a
               list containing the members of
               <var>commonMethods</var>.</li>
               <li>Set <var>outData</var>.data to a <a>structured
-              clone</a> of <var>inData</var>.<code>data</code>.
+              clone</a> of <var>inData</var>.data.
               </li>
               <li>Append <var>outData</var> to
               <var>dataList</var>.</li>
             </ol>
           </li>
-          <li>Set <code>methodData</code> to
+          <li>Set <a>methodData</a> to
           <var>dataList</var>.</li>
         </ol>
       </section>
       <section>
-        <h3><dfn>Modifiers Population Algorithm</dfn></h3>
-        <p>To initialize the value of the <code>modifiers</code>,
+        <h2><dfn>Modifiers Population Algorithm</dfn></h2>
+        <p>To initialize the value of the <a>modifiers</a>,
         the user agent MUST perform the following steps or their
         equivalent:</p>
         <ol>
@@ -1001,15 +1010,15 @@
           set.</li>
           <li>For each <a>PaymentInstrument</a> <var>instrument</var> in
           the <a>payment handler</a>'s
-          <code>PaymentManager.instruments</code>, add all entries
-          in <var>instrument</var>.<code>enabledMethods</code> to <var>
+          <a>PaymentManager</a>.<a data-lt="PaymentManager.instruments">instruments</a>, add all entries
+          in <var>instrument</var>.<a data-lt="PaymentInstrument.enabledMethods">enabledMethods</a> to <var>
             registeredMethods</var>.
           </li>
-          <li>Create a new empty <code>Sequence</code>.</li>
+          <li>Create a new empty <a>Sequence</a>.</li>
           <li>Set <var>modifierList</var> to the newly created
-          <code>Sequence</code>.</li>
+          <a>Sequence</a>.</li>
           <li>For each item in
-          <code>PaymentRequest</code>@<var>[[\paymentDetails]]</var>.<code>modifiers</code>
+          <a>PaymentRequest</a>@<var>[[\paymentDetails]]</var>.<a>modifiers</a>
           in the corresponding payment request, perform the
           following steps:
             <ol>
@@ -1017,84 +1026,83 @@
               consideration.</li>
               <li>Set <var>commonMethods</var> to the set
               intersection of
-              <var>inModifier</var>.<code>supportedMethods</code>
+              <var>inModifier</var>.<a>supportedMethods</a>
               and <var>registeredMethods</var>.</li>
               <li>If <var>commonMethods</var> is empty, skip the
               remaining substeps and move on to the next item (if
               any).</li>
-              <li>Create a new <code>PaymentDetailsModifier</code>
+              <li>Create a new <a>PaymentDetailsModifier</a>
               object.</li>
               <li>Set <var>outModifier</var> to the newly created
-              <code>PaymentDetailsModifier</code>.</li>
+              <a>PaymentDetailsModifier</a>.</li>
               <li>Set
-              <var>outModifier</var>.<code>supportedMethods</code>
+              <var>outModifier</var>.<a>supportedMethods</a>
               to a list containing the members of
               <var>commonMethods</var>.</li>
-              <li>Set <var>outModifier</var>.<code>total</code> to
+              <li>Set <var>outModifier</var>.<a>total</a> to
               a <a>structured clone</a> of
-              <var>inModifier</var>.<code>total</code>.
+              <var>inModifier</var>.<a>total</a>.
               </li>
               <li>Append <var>outModifier</var> to
               <var>modifierList</var>.</li>
             </ol>
           </li>
-          <li>Set <code>modifiers</code> to
+          <li>Set <a>modifiers</a> to
           <var>modifierList</var>.</li>
         </ol>
       </section>
     </section>
-    <section>
-      <h3>Invocation</h3>
-      <section data-dfn-for="ServiceWorkerGlobalScope">>
-        <h3>Extension to <code>ServiceWorkerGlobalScope</code></h3>
-        <p>The Service Worker specification [[!SERVICE-WORKERS]] defines a
-          <dfn>ServiceWorkerGlobalScope</dfn> interface,
-	  which this specification extends.</p>
+    <section data-dfn-for="ServiceWorkerGlobalScope" data-link-for="ServiceWorkerGlobalScope">
+      <h2>Extension to <a>ServiceWorkerGlobalScope</a></h2>
+        <p>
+	  This specification extends the <a>ServiceWorkerGlobalScope</a> interface.</p>
         <pre class="idl">
         partial interface ServiceWorkerGlobalScope {
           attribute EventHandler onpaymentrequest;
         };
-      </pre>
-        <dl>
-          <dt><dfn>onpaymentrequest</dfn> attribute</dt>
-          <dd>
-            The <code>onpaymentrequest</code> attribute is an
+	</pre>
+	<section>
+	  <h2><dfn>onpaymentrequest</dfn> attribute</h2>
+          <p>
+            The <a>onpaymentrequest</a> attribute is an
             <a>event handler</a> whose corresponding <a>event
-            handler event type</a> is <code>paymentrequest</code>.
-          </dd>
-        </dl>
-        <p>The <a>PaymentRequestEvent</a> interface represents a
-        received <a>PaymentRequest</a>.</p>
-      </section>
-    <section data-dfn-for="PaymentRequestEvent">
-        <h3>The <dfn>PaymentRequestEvent</dfn></h3>
-        <p>The <code>PaymentRequestEvent</code> represents a received
-        <a>PaymentRequest</a>.</p>
-        <pre class="idl">
-      [Exposed=ServiceWorker]
-      interface PaymentRequestEvent : ExtendableEvent {
+              handler event type</a> is <a>paymentrequest</a>.
+          </p>
+	</section>
+  </section>
+  <section data-dfn-for="PaymentRequestEvent" data-link-for="PaymentRequestEvent">
+    <h2>The <dfn>PaymentRequestEvent</dfn></h2>
+    <p>The <a>PaymentRequestEvent</a> represents a received <a>PaymentRequest</a>.</p>
+      <pre class="idl">
+	[Exposed=ServiceWorker]
+	interface PaymentRequestEvent : ExtendableEvent {
         readonly attribute PaymentAppRequest appRequest;
         Promise&lt;WindowClient&gt; openWindow(USVString url);
         void respondWith(Promise&lt;PaymentAppResponse&gt;appResponse);
-      };
-	</pre>
-	<dl>
-	  <dt><dfn id="appRequest">appRequest</dfn> attribute</dt>
-          <dd>This attribute contains the <a>PaymentAppRequest</a>
-          associated with this <a>PaymentRequest</a>.</dd>
-          <dt><dfn>openWindow()</dfn> method</dt>
-          <dd>This method is used by the payment handler to show a
+	};
+      </pre>
+      
+      <section>
+	<h2><dfn>appRequest</dfn> attribute</h2>
+        <p>This attribute contains the <a>PaymentAppRequest</a>
+          associated with this <a>PaymentRequest</a>.</p>
+      </section>
+      <section>
+	<h2><dfn>openWindow</dfn>() method</h2>
+        <p>This method is used by the payment handler to show a
           window to the user. When called, it runs the <a>open window
-          algorithm</a>.</dd>
-          <dt><dfn>respondWith()</dfn> method</dt>
-          <dd>This method is used by the payment handler to provide
-          a <a>PaymentAppResponse</a> when the payment successfully
-            completes.</dd>
-	</dl>
-        </section>
-        <section>
-          <h3>Internal Slots</h3>
-          <p>Instances of <a>PaymentRequestEvent</a> are created with
+            algorithm</a>.</p>
+      </section>
+      <section>
+	<h2><dfn>respondWith</dfn>() method</h2>
+	<p>This method is used by the payment handler to provide
+	  a <a>PaymentAppResponse</a> when the payment successfully
+	  completes.</p>
+      </section>
+    </section>
+    <section>
+      <h2>Internal Slots</h2>
+      <p>Instances of <a>PaymentRequestEvent</a> are created with
           the internal slots in the following table:</p>
           <table>
             <tr>
@@ -1114,15 +1122,13 @@
           </table>
         </section>
         <section>
-          <h3>Handling a PaymentRequestEvent</h3>
+          <h2>Handling a PaymentRequestEvent</h2>
           <p>Upon receiving a <a>PaymentRequest</a> by way of
           <a data-cite="!PAYMENT-REQUEST-API#show-method">PaymentRequest.show()</a> and subsequent user
           selection of a payment handler, the <a>user agent</a>
           MUST run the following steps:</p>
           <ol>
-            <li>Let <var>registration</var> be the <a>service
-            worker registration</a> corresponding to the <a>payment
-            handler</a> selected by the user.
+            <li>Let <var>registration</var> be the <a>ServiceWorkerRegistration</a> corresponding to the <a>payment handler</a> selected by the user.
             </li>
             <li>If <var>registration</var> is not found, reject the
             <a>Promise</a> that was created by
@@ -1131,7 +1137,7 @@
             "<a>InvalidStateError</a>" and terminate these steps.
             </li>
             <li>Invoke the <a>handle functional event</a> algorithm
-            with a <a>service worker registration</a> of
+            with a <a>ServiceWorkerRegistration</a> of
             <var>registration</var> and <var>callbackSteps</var>
             set to the following steps:
               <ol>
@@ -1140,11 +1146,11 @@
                 <li>Create a <a>trusted event</a>, <var>e</var>,
                 that uses the
                 <a>PaymentRequestEvent</a> interface,
-                with the event type <code>paymentrequest</code>,
+                with the event type <a>paymentrequest</a>,
                 which does not bubble, cannot be canceled, and has
                 no default action.
                 </li>
-                <li>Set the <a href="#apprequest">appRequest</a> attribute of
+                <li>Set the <a data-lt="PaymentRequestEvent.appRequest">appRequest</a> attribute of
                 <var>e</var> to a new <a>PaymentAppRequest</a>
                 instance, populated as described in <a href=
                 "#sec-app-request"></a>.
@@ -1158,7 +1164,7 @@
                 a <a>PaymentAppResponse</a> as described in
                 <a href="#sec-payment-app-response"></a>, reject
                 the <a>Promise</a> that was created by
-                < data-cite="!PAYMENT-REQUEST-API#show-method">PaymentRequest.show()</a> with a
+                <a data-cite="!PAYMENT-REQUEST-API#show-method">PaymentRequest.show()</a> with a
                 <a>DOMException</a> whose value
                 "<a>OperationError</a>".
                 </li>
@@ -1167,9 +1173,8 @@
           </ol>
         </section>
       </section>
-    </section>
     <section>
-      <h3><dfn data-lt="payment handler window">Payment Handler Windows</dfn></h3>
+      <h2><dfn data-lt="payment handler window">Windows</dfn></h2>
       <p>An invoked payment handler may or may not need to display
       information about itself or request user input. Some examples
       of potential payment handler displays include:</p>
@@ -1200,7 +1205,7 @@
       than one client window using this method.</p>
 
       <section>
-        <h3><dfn>Open Window Algorithm</dfn></h3>
+        <h2><dfn>Open Window Algorithm</dfn></h2>
         <p class="issue" data-number="115">This algorithm is <i>very</i> similar to
         the <a data-cite="!SERVICE-WORKERS#clients-openwindow">
         Open Window Algorithm</a> in the Service Workers
@@ -1223,13 +1228,13 @@
           <li>If the url parsing throws an exception, return a <a>Promise</a>
           rejected with that exception.</li>
           <li>If url is about:blank, return a <a>Promise</a> rejected with
-          a <code>TypeError</code>.
+          a <a>TypeError</a>.
           </li>
           <li>Let <var>promise</var> be a new <a>Promise</a>.
           </li>
           <li>Run these steps <a data-cite="!whatwg-html#in-parallel">in parallel</a>:
             <ol>
-              <li>Let <var>newContext</var> be a new <a data-cite="!whatwg-html#top-level-browsing-context">top level
+              <li>Let <var>newContext</var> be a new <a data-cite="!whatwg-html#top-level-browsing-context">top-level
               browsing context</a>.
               </li>
               <li><a data-cite="!whatwg-html#navigate">Navigate</a> <var>newContext</var> to <var>url</var>,
@@ -1238,8 +1243,7 @@
               <var>promise</var> with that exception and abort
               these steps.</li>
               <li>If the origin of <var>newContext</var> is not the same as the
-              <var>event</var>.<a href="#appRequest">appRequest</a>.<a href=
-              "#dom-paymentapprequest-origin">origin</a>, then:
+              <var>event</var>.<a data-lt="PaymentRequestEvent.appRequest">appRequest</a>.<a data-lt="PaymentAppRequest.origin">origin</a>, then:
                 <ol>
                   <li>Reject <var>promise</var> with a <a>DOMException</a> whose name is "<a>SecurityError</a>".</li>
                   <li>Abort these steps.</li>
@@ -1271,120 +1275,15 @@
           <li>Return <var>promise</var>.</li>
         </ol>
       </section>
-    </section>
-    <section data-dfn-for="PaymentAppResponse">
-      <h2><dfn>PaymentAppResponse</dfn> dictionary</h2>
-      The PaymentAppResponse
-      is conveyed using the following dictionary:
-      <pre class="idl">
-      dictionary PaymentAppResponse {
-        DOMString methodName;
-        object details;
-      };
-    </pre>
-      <dl>
-        <dt><dfn>methodName</dfn> attribute</dt>
-        <dd>
-          The <a>payment method identifier</a> for the <a>payment
-          method</a> that the user selected to fulfil the
-          transaction.
-        </dd>
-        <dt><dfn>details</dfn> attribute</dt>
-        <dd>
-          A <a>JSON-serializable</a> object that provides a
-          <a>payment method</a> specific message used by the
-          merchant to process the transaction and determine
-          successful fund transfer.
-        </dd>
-        <dd>
-          <p>The user agent receives a successful response from the
-          payment handler through resolution of the Promise
-          provided to the <code>respondWith</code> function of the
-          corresponding <a>PaymentRequestEvent</a> dictionary. The
-          application is expected to resolve the Promise with a
-          <code>PaymentAppResponse</code> instance containing the
-          payment response. In case of user cancellation or error,
-          the application may signal failure by rejecting the
-          Promise.</p>
-          <p>If the Promise is rejected, the user agent MUST run
-          the <dfn>payment app failure algorithm</dfn>. The exact
-          details of this algorithm are left to 
-          implementers. Acceptable behaviors include,
-          but are not limited to:</p>
-          <ul>
-            <li>Letting the user try again, with the same payment
-            handler or with a different one.</li>
-            <li>Rejecting the Promise that was created by
-            <a data-cite="!PAYMENT-REQUEST-API#show-method">PaymentRequest.show()</a>.</li>
-          </ul>
-          <p>If this Promise is successfully resolved, the user
-          agent MUST run the <a>user accepts the payment request
-          algorithm</a> as defined in [[!PAYMENT-REQUEST-API]],
-          replacing steps 6 and 7 with these steps or their
-          equivalent:</p>
-          <ol>
-            <li>Set <var>appResponse</var> to the
-            <code>PaymentAppResponse</code> instance used to
-            resolve the
-            <a>PaymentRequestEvent</a><code>.respondWith</code>
-            Promise.
-            </li>
-            <li>If <var>appResponse</var>.<code>methodName</code>
-            is not present or not set to one of the values from <a>
-              PaymentRequestEvent</a>.<code>appRequest</code>, run
-              the <a>payment app failure algorithm</a> and
-              terminate these steps.
-            </li>
-            <li>Create a <a>structured clone</a> of
-            <var>appResponse</var>.<code>methodName</code> and
-            assign it to
-            <var>response</var>.<code>methodName</code>.
-            </li>
-            <li>If <var>appResponse</var>.<code>details</code> is
-            not present, run the <a>payment app failure
-            algorithm</a> and terminate these steps.
-            </li>
-            <li>Create a <a>structured clone</a> of
-            <var>appResponse</var>.<code>details</code> and assign
-            it to <var>response</var>.<code>details</code>.
-            </li>
-          </ol>
-          <p>The following example shows how to respond to a
-          payment request:</p>
-          <pre class="example highlight" title=
-          "Sending a Payment Response">
-      paymentRequestEvent.respondWith(new Promise(function(accept,reject) {
-        /* ... processing may occur here ... */
-        accept({
-          methodName: "basic-card",
-          details: {
-            cardHolderName:   "John Smith",
-            cardNumber:       "1232343451234",
-            expiryMonth:      "12",
-            expiryYear :      "2020",
-            cardSecurityCode: "123"
-           }
-        });
-      });
-    </pre>
-          <p class="note">[[!PAYMENT-REQUEST-API]] defines a
-          <code>paymentRequestID</code> that parties in the
-          ecosystem (including payment app providers and payees)
-          may use for reconciliation after network or other
-          failures.</p>
-        </dd>
-      </dl>
-    </section>
-    <section id="post-example">
-      <h3>Example of handling the <code>paymentrequest</code>
-      event</h3>
+
+      	<section id="post-example">
+      <h2>Example of handling the <a>PaymentRequestEvent</a></h2>
       <p>This example shows how to write a service worker that
 	listens to the <a>PaymentRequestEvent</a>. When a
 	<a>PaymentRequestEvent</a> is received, the service worker opens a window in order
       to interact with the user.</p>
       <pre class="example highlight" title=
-      "Handling the PaymentRequestEvent" id=
-      "example-paymentrequestevent">
+      "Handling the PaymentRequestEvent">
       self.addEventListener('paymentrequest', function(e) {
         e.respondWith(new Promise(function(resolve, reject) {
           self.addEventListener('message', listener = function(e) {
@@ -1448,11 +1347,121 @@ window.addEventListener("message", function(e) {
 &lt;/script&gt; &lt;/body&gt; &lt;/html&gt;
     </pre>
     </section>
-  </section>
+
+    </section>
+    <section>
+      <h2>Response</h2>
+      <section data-dfn-for="PaymentAppResponse" data-link-for="PaymentAppResponse">
+	<h2><dfn>PaymentAppResponse</dfn> dictionary</h2>
+      The PaymentAppResponse is conveyed using the following dictionary:
+	<pre class="idl">
+	  dictionary PaymentAppResponse {
+          DOMString methodName;
+          object details;
+	  };
+	</pre>
+	
+	<section>
+	  <h2><dfn>methodName</dfn> attribute</h2>
+          <p>
+          The <a>payment method identifier</a> for the <a>payment
+          method</a> that the user selected to fulfil the
+          transaction.
+        </p>
+	</section>
+      <section>
+	<h2><dfn>details</dfn> attribute</h2>
+        <p>
+          A <a>JSON-serializable</a> object that provides a
+          <a>payment method</a> specific message used by the
+          merchant to process the transaction and determine
+          successful fund transfer.
+        </p>
+          <p>The user agent receives a successful response from the
+          payment handler through resolution of the Promise
+          provided to the <a data-lt="PaymentRequestEvent.respondWith">respondWith()</a> function of the
+          corresponding <a>PaymentRequestEvent</a> dictionary. The
+          application is expected to resolve the Promise with a
+          <a>PaymentAppResponse</a> instance containing the
+          payment response. In case of user cancellation or error,
+          the application may signal failure by rejecting the
+          Promise.</p>
+          <p>If the Promise is rejected, the user agent MUST run
+          the <dfn>payment app failure algorithm</dfn>. The exact
+          details of this algorithm are left to 
+          implementers. Acceptable behaviors include,
+          but are not limited to:</p>
+          <ul>
+            <li>Letting the user try again, with the same payment
+            handler or with a different one.</li>
+            <li>Rejecting the Promise that was created by
+            <a data-cite="!PAYMENT-REQUEST-API#show-method">PaymentRequest.show()</a>.</li>
+          </ul>
+      </section>
+      </section>
+      <section>
+	<h2>Extention to User Accepts the Payment Request Algorithm</h2>
+          <p>If the Promise is successfully resolved, the user
+          agent MUST run the <a>user accepts the payment request
+          algorithm</a> as defined in [[!PAYMENT-REQUEST-API]],
+          replacing steps 6 and 7 with these steps or their
+          equivalent:</p>
+          <ol>
+            <li>Set <var>appResponse</var> to the
+            <a>PaymentAppResponse</a> instance used to
+            resolve the
+            <a>PaymentRequestEvent</a>.<a data-lt="PaymentRequestEvent.respondWith">respondWith()</a>
+            Promise.
+            </li>
+            <li>If <var>appResponse</var>.<a data-lt="PaymentAppResponse.methodName">methodName</a>
+            is not present or not set to one of the values from <a>
+              PaymentRequestEvent</a>.<a data-lt="PaymentRequestEvent.appRequest">appRequest</a>, run
+              the <a>payment app failure algorithm</a> and
+              terminate these steps.
+            </li>
+            <li>Create a <a>structured clone</a> of
+            <var>appResponse</var>.<a data-lt="PaymentAppResponse.methodName">methodName</a> and
+            assign it to
+            <var>response</var>.<a data-lt="PaymentAppResponse.methodName">methodName</a>.
+            </li>
+            <li>If <var>appResponse</var>.<a>details</a> is
+            not present, run the <a>payment app failure
+            algorithm</a> and terminate these steps.
+            </li>
+            <li>Create a <a>structured clone</a> of
+            <var>appResponse</var>.<a>details</a> and assign
+            it to <var>response</var>.<a>details</a>.
+            </li>
+          </ol>
+          <p>The following example shows how to respond to a
+          payment request:</p>
+          <pre class="example highlight" title=
+          "Sending a Payment Response">
+      paymentRequestEvent.respondWith(new Promise(function(accept,reject) {
+        /* ... processing may occur here ... */
+        accept({
+          methodName: "basic-card",
+          details: {
+            cardHolderName:   "John Smith",
+            cardNumber:       "1232343451234",
+            expiryMonth:      "12",
+            expiryYear :      "2020",
+            cardSecurityCode: "123"
+           }
+        });
+      });
+    </pre>
+          <p class="note">[[!PAYMENT-REQUEST-API]] defines an
+          <a>ID</a> that parties in the
+          ecosystem (including payment app providers and payees)
+          may use for reconciliation after network or other
+          failures.</p>
+      </section>
+    </section>
   <section id="security">
     <h2>Security and Privacy Considerations</h2>
     <section>
-      <h3>Information about the User Environment</h3>
+      <h2>Information about the User Environment</h2>
       <ul>
         <li>The API does not share information about the user's
         registered payment handlers. Information from origins is
@@ -1464,7 +1473,7 @@ window.addEventListener("message", function(e) {
       </ul>
     </section>
     <section>
-      <h3>User Consent before Payment</h3>
+      <h2>User Consent before Payment</h2>
       <ul>
         <li>One goal of this specification is to minimize the user
         interaction required to make a payment. At the same time,
@@ -1474,7 +1483,7 @@ window.addEventListener("message", function(e) {
       </ul>
     </section>
     <section>
-      <h3>Secure Communications</h3>
+      <h2>Secure Communications</h2>
       <ul>
         <li>See <a href=
         "https://www.w3.org/TR/service-workers/#security-considerations">
@@ -1486,14 +1495,14 @@ window.addEventListener("message", function(e) {
       </ul>
     </section>
     <section>
-      <h3>Payment App Authenticity</h3>
+      <h2>Payment App Authenticity</h2>
       <p class="note">The Web Payments Working Group is also
       discussing Payment App authenticity; see the (draft) <a href=
       "https://w3c.github.io/webpayments/proposals/Payment-Manifest-Proposal.html">
       Payment Method Manifest</a>.</p>
     </section>
     <section>
-      <h3>Data Validation</h3>
+      <h2>Data Validation</h2>
       <ul>
         <li>Payees should validate that the data they have received
         through the paymentRequest API is what they expect (e.g.,
@@ -1501,7 +1510,7 @@ window.addEventListener("message", function(e) {
       </ul>
     </section>
     <section>
-      <h3>Private Browsing Mode</h3>
+      <h2>Private Browsing Mode</h2>
       <ul>
         <li>When the Payment Request API is invoked in a "private
         browsing mode," the user agent should launch payment

--- a/index.html
+++ b/index.html
@@ -869,20 +869,20 @@
       <section>
 	<h2><dfn>topLevelOrigin</dfn> attribute</h2>
         <p>
-          This attribute a string that indicates the <a data-cite=
+          This attribute is a string that indicates the <a data-cite=
 							"!HTML5#origin">origin</a>
-          of the top level <a>payee</a> web page. It MUST be formatted
-          according to the "<a href=
-			       "https://tools.ietf.org/html/rfc6454#section-6.1">Unicode
-            Serialization of an Origin</a>" algorithm defined in
+          of the top level <a>payee</a> web page. The string MUST be formatted
+          according to the "<a data-cite="!RFC6454#section-6.1">Unicode Serialization of an Origin</a>" algorithm defined in
           section 6.1 of [[!RFC6454]].
         </p>
       </section>
       <section>
 	<h2><dfn>paymentRequestOrigin</dfn> attribute</h2>
         <p>
-          If a <a>PaymentRequest</a> is initiated within an iframe
-	  whose <a data-cite="!HTML5#origin">origin</a> differs from <a>topLevelOrigin</a>, this attribute indicates the iframe origin. It MUST be formatted according to the "<a href="https://tools.ietf.org/html/rfc6454#section-6.1">Unicode Serialization of an Origin</a>" algorithm defined in section 6.1 of [[!RFC6454]].
+          This attribute is a string that indicates the <a data-cite=
+							"!HTML5#origin">origin</a>
+	  where a <a>PaymentRequest</a> was initialized.
+	  For example, when a <a>PaymentRequest</a> is initialized within an iframe, the value of this attribute is the origin of the iframe. The string MUST be formatted according to the "<a data-cite="!RFC6454#section-6.1">Unicode Serialization of an Origin</a>" algorithm defined in section 6.1 of [[!RFC6454]].
         </p>
       </section>
       <section>
@@ -1228,7 +1228,13 @@
               with exceptions enabled and replacement enabled.</li>
               <li>If the navigation throws an exception, reject
 		<var>promise</var> with that exception and abort
-              these steps.</li>
+		these steps.</li>
+	       <li>If the origin of <var>newContext</var> is not the same as the <a>server worker client</a> origin associated with the payment handler, then:
+              <ol>
+                <li>Reject <var>promise</var> with a <a>DOMException</a> whose name is "<a>SecurityError</a>".</li>
+                <li>Abort these steps.</li>
+              </ol>
+            </li>
               <li>Let <var>client</var> be the result of running the
               <a data-cite="!SERVICE-WORKERS#capture-windowclient-algorithm">
                 capture window client</a> algorithm with <var>newContext</var> as the

--- a/index.html
+++ b/index.html
@@ -369,13 +369,6 @@
       payment handler to indicate the <a>PaymentInstrument</a>
 	selected by the user.</p>
 
-      
-      <pre class="example js" title="Removing all instruments">
-        return paymentManager.instruments.keys().then((keys) =&gt; {
-          Promise.all(keys.map(paymentManager.instruments.delete(key)))
-        });
-      </pre>
-
       <section>
         <h2><dfn>delete()</dfn> method</h2>
         <p>
@@ -475,7 +468,7 @@
             <li> Run the following steps in parallel:
               <ol>
 		<li>Remove all <a>PaymentInstrument</a>s from
-		  the collection and resolve <var>p</var> with <b>true</b>.</li>
+		  the collection and resolve <var>p</var>.</li>
               </ol>
 	    </li>
             <li> Return <var>p</var></li>
@@ -635,7 +628,7 @@
           <li> Run the following steps in parallel:
             <ol>
 	      <li>Remove all <a>PaymentWallets</a> from
-		the collection and resolve <var>p</var> with <b>true</b>.</li>
+		the collection and resolve <var>p</var>.</li>
             </ol>
 	  </li>
           <li> Return <var>p</var></li>

--- a/index.html
+++ b/index.html
@@ -61,16 +61,6 @@
                     ],
                     status:   "WD"
                 },
-                "BASIC-CARD": {
-                    title:    "Basic Card Payment",
-                    href:     "https://www.w3.org/TR/payment-method-basic-card/",
-                    authors:  [
-                        "Adrian Bateman",
-                        "Zach Koch",
-                        "Roy McElmurray"
-                    ],
-                    status:   "WD"
-                },
                 "METHOD-IDENTIFIERS": {
                     title:    "Payment Method Identifiers",
                     href:     "https://www.w3.org/TR/payment-method-id/",
@@ -176,76 +166,73 @@
     specifications.</p>
     <dl>
       <dt>Payment Request API</dt>
-      <dd>The terms <dfn>payment method</dfn>, <dfn>PaymentRequest</dfn>,
-      <dfn>PaymentResponse</dfn>, <dfn>supportedMethods</dfn>, <dfn>paymentDetailsModifier</dfn>, <dfn>paymentDetails</dfn>, <dfn>PaymentMethodData</dfn>, <dfn>ID</dfn> and <dfn>user accepts the payment request algorithm</dfn>  are defined by the Payment Request
-      API specification [[!PAYMENT-REQUEST-API]]. This specification also relies on the Payment Request API usage of <dfn>Promise</dfn>, <dfn>internal slot</dfn>, <dfn>TypeError</dfn>, <dfn>JSON.stringify</dfn>, and <dfn>JSON-serializable</dfn>.</dd>
+      <dd>The terms <dfn data-cite="!PAYMENT-REQUEST-API#payment-method">payment method</dfn>, <dfn data-cite="!PAYMENT-REQUEST-API#dom-paymentrequest">PaymentRequest</dfn>,
+      <dfn data-cite="!PAYMENT-REQUEST-API#dom-paymentresponse">PaymentResponse</dfn>, <dfn data-cite="!PAYMENT-REQUEST-API#dom-paymentmethoddata-supportedmethods">supportedMethods</dfn>, <dfn data-cite="!PAYMENT-REQUEST-API#paymentdetailsmodifier-dictionary">paymentDetailsModifier</dfn>, <dfn data-cite="!PAYMENT-REQUEST-API#paymentdetailsinit-dictionary">paymentDetailsInit</dfn>, <dfn data-cite="!PAYMENT-REQUEST-API#paymentmethoddata-dictionary">PaymentMethodData</dfn>, <dfn data-cite="!PAYMENT-REQUEST-API#id-attribute">ID</dfn>, <dfn data-cite="!PAYMENT-REQUEST-API#show-method">show()</dfn>, and <dfn data-cite="!PAYMENT-REQUEST-API#user-accepts-the-payment-request-algorithm">user accepts the payment request algorithm</dfn>  are defined by the Payment Request
+      API specification [[!PAYMENT-REQUEST-API]].
+      </dd>
+      <dt>
+          ECMA-262 6th Edition, The ECMAScript 2015 Language Specification
+      </dt>
+      <dd>
+        The terms <dfn data-cite=
+		       "!ECMA-262-2015#sec-promise-objects">Promise</dfn>, <dfn data-cite=
+										"!ECMA-262-2015#sec-object-internal-methods-and-internal-slots">internal
+          slot</dfn>, <code><dfn data-cite=
+          "!ECMA-262-2015#sec-native-error-types-used-in-this-standard-typeerror">
+          TypeError</dfn></code>, and <code><dfn data-cite=
+          "!ECMA-262-2015#sec-json.stringify">JSON.stringify</dfn></code> are
+          defined by [[!ECMA-262-2015]].
+          <p>
+            The term <dfn data-lt=
+            "JSON-serialized|JSON-serializable">JSON-serialize</dfn> applied to
+            a given object means to run the algorithm specified by the original
+            value of the <a>JSON.stringify</a> function on the supplied object,
+            passing the supplied object as the sole argument, and return the
+            resulting string. This can throw an exception.
+          </p>
+        </dd>
       <dt>Payment Method Identifiers</dt>
-      <dd>The terms <dfn data-lt="payment method identifier|payment method identifiers">payment method identifier</dfn> is defined by the Payment Method
+      <dd>The terms <dfn data-lt="payment method identifiers">payment method identifier</dfn> is defined by the Payment Method
 	Identifier specification [[!METHOD-IDENTIFIERS]].</dd>
       <dt>Basic Card Payment</dt>
-      <dd>The terms <dfn>basic-card</dfn>, <dfn>supportedNetworks</dfn>, and <dfn>supportedTypes</dfn> are defined in [[BASIC-CARD]].</dd>
+      <dd>The terms <dfn data-cite="!PAYMENT-REQUEST-API#method-id">basic-card</dfn>, <dfn data-cite="!PAYMENT-REQUEST-API#supportedNetworks">supportedNetworks</dfn>, and <dfn data-cite="!PAYMENT-REQUEST-API#supportedTypes">supportedTypes</dfn> are defined in [[!payment-method-basic-card]].</dd>
 
       <dt>HTML5</dt>
-      <dd>The terms <dfn>global object</dfn>, <dfn>origin</dfn>,
+      <dd>The terms <dfn>global object</dfn>,
       <dfn>top-level browsing context</dfn>, <dfn>structured
       clone</dfn>, <dfn>event handler</dfn>, <dfn>event handler
 	event type</dfn>, <dfn>trusted event</dfn>, and
       <dfn>user interaction task source</dfn> are defined by [[!HTML5]].</dd>
-      <dt>DOM4</dt>
-      <dd>
-        <p><dfn>DOMException</dfn> and the following DOMException
-        types from [[!DOM4]] are used:</p>
-        <table>
-          <tr>
-            <th>Type</th>
-            <th>Message (optional)</th>
-          </tr>
-          <tr>
-            <td><dfn>AbortError</dfn></td>
-            <td>The operation was aborted</td>
-          </tr>
-          <tr>
-            <td><dfn>InvalidStateError</dfn></td>
-            <td>The object is in an invalid state</td>
-          </tr>
-          <tr>
-            <td><dfn>NotFoundError</dfn></td>
-            <td>The object can not be found here.</td>
-          </tr>
-          <tr>
-            <td><dfn>SecurityError</dfn></td>
-            <td>The operation is only supported in a secure
-            context</td>
-          </tr>
-          <tr>
-            <td><dfn>OperationError</dfn></td>
-            <td>The operation failed for an operation-specific
-            reason.</td>
-          </tr>
-        </table>
-	<p>The term <dfn data-cite= "!DOM4#firing-events">fires</dfn> (an event) is defined in [[!DOM4]].
+      <dt>RFC6454</dt>
+      <dd>The term <dfn>origin</dfn> is defined in [[!RFC6454]].</dd>
+      <dt>DOM</dt>
+      <dd>The term <dfn data-cite= "!DOM4#firing-events">fires</dfn> (an event) is defined in [[!DOM4]].
       </dd>
-      <dt>WebIDL</dt>
+      <dt>Web IDL</dt>
       <dd>
-        <p>The following DOMException types from [[!WEBIDL]] are
-        used:</p>
-        <table>
-          <tr>
-            <th>Type</th>
-            <th>Message (optional)</th>
-          </tr>
-          <tr>
-            <td><dfn>NotAllowedError</dfn></td>
-            <td>The request is not allowed by the user agent or the
-            platform in the current context.</td>
-          </tr>
-        </table>
-      </dd>
+        <p><dfn data-cite=
+            "!WEBIDL-LS#dfn-DOMException">DOMException</dfn> and the
+            following <a>DOMException</a> types from [[!WEBIDL-LS]] are used:
+          </p>
+          <ul>
+            <li>"<code><dfn data-cite=
+            "!WEBIDL-LS#invalidstateerror">InvalidStateError</dfn></code>"
+            </li>
+            <li>"<code><dfn data-cite=
+            "!WEBIDL-LS#notfounderror">NotFoundError</dfn></code>"
+            </li>
+            <li>"<code><dfn data-cite=
+            "!WEBIDL-LS#operationerror">OperationError</dfn></code>"
+            </li>
+            <li>"<code><dfn data-cite=
+            "!WEBIDL-LS#securityerror">SecurityError</dfn></code>"
+            </li>
+          </ul>
       <dt>Secure Contexts</dt>
       <dd>The terms <dfn>secure context</dfn> is defined by the
       Secure Contexts specification [[!POWERFUL-FEATURES]].</dd>
       <dt>Service Workers</dt>
-      <dd>The terms <dfn>service worker</dfn>, <dfn>ServiceWorkerRegistration</dfn>, <dfn>ServiceWorkerGlobalScope</dfn>, <dfn>handle functional event</dfn>, <dfn>extend lifetime promises</dfn>, and <dfn>scope URL</dfn> are defined in
+      <dd>The terms <code><dfn>service worker</dfn></code>, <code><dfn>ServiceWorkerRegistration</dfn></code>, <code><dfn>ServiceWorkerGlobalScope</dfn></code>, <dfn>handle functional event</dfn>, <dfn>extend lifetime promises</dfn>, and <dfn>scope URL</dfn> are defined in
       [[!SERVICE-WORKERS]].</dd>
     </dl>
   </section>
@@ -274,8 +261,7 @@
           of Instruments supported by the payment handler.</li>
         </ul>
       </li>
-      <li>When the merchant (or other <dfn>payee</dfn>) calls Payment Request API (e.g., when
-      the user pushes a button on a checkout page), the user agent
+      <li>When the merchant (or other <dfn>payee</dfn>) calls the [[PAYMENT-REQUEST-API]] method  <a>show()</a> (e.g., when the user pushes a button on a checkout page), the user agent
       computes a list of matching payment handlers, comparing the
       payment methods accepted by the merchant with those supported by
       registered payment handlers. For payment methods that support
@@ -321,7 +307,7 @@
   <section id="registration">
     <h2><dfn>Payment Handler</dfn> Registration</h2>
     <section>
-      <h2>Extension to the ServiceWorkerRegistration interface</h2>
+      <h2>Extension to the <code>ServiceWorkerRegistration</code> interface</h2>
       <p>This specification extends the <a>ServiceWorkerRegistration</a> interface.</p>
       <pre class="idl">
         partial interface ServiceWorkerRegistration {
@@ -373,19 +359,19 @@
       </pre>
       <p>The <a>PaymentInstruments</a> interface represents a collection of
       payment instruments, each uniquely identified by an <dfn>instrumentKey</dfn>.
-      The <a>instrumentKey</a> identifier will be passed to the
+      The <var>instrumentKey</var> identifier will be passed to the
       payment handler to indicate the <a>PaymentInstrument</a>
 	selected by the user.</p>
 
       
-      <pre class="example highlight" title="Removing all instruments">
+      <pre class="example js" title="Removing all instruments">
         return paymentManager.instruments.keys().then((keys) =&gt; {
           Promise.all(keys.map(paymentManager.instruments.delete(key)))
         });
       </pre>
 
       <section>
-        <h2><dfn>delete</dfn> method</h2>
+        <h2><dfn>delete()</dfn> method</h2>
         <p>
           When called, this method executes the following steps:</p>
           <ol>
@@ -393,7 +379,7 @@
             <li> Run the following steps in parallel:
             <ol>
               <li> If the collection contains a <a>PaymentInstrument</a>
-              with a matching <a>instrumentKey</a>, remove it from
+              with a matching <var>instrumentKey</var>, remove it from
               the collection and resolve <var>p</var> with <b>true</b>.</li>
               <li> Otherwise, resolve <var>p</var> with <b>false</b>.</li>
             </ol>
@@ -402,7 +388,7 @@
 	</section>
 
       <section>
-        <h2><dfn>get</dfn> method</h2>
+        <h2><dfn>get()</dfn> method</h2>
         <p>
           When called, this method executes the following steps:</p>
           <ol>
@@ -410,7 +396,7 @@
             <li> Run the following steps in parallel:
             <ol>
               <li> If the collection contains a <a>PaymentInstrument</a>
-              with a matching <a>instrumentKey</a>, resolve <var>p</var>
+              with a matching <var>instrumentKey</var>, resolve <var>p</var>
               with that <a>PaymentInstrument</a>.
               <li> Otherwise, reject <var>p</var> with a
               <a>DOMException</a> whose value is
@@ -421,7 +407,7 @@
       </section>
 
       <section>
-        <h2><dfn>keys</dfn> method</h2>
+        <h2><dfn>keys()</dfn> method</h2>
         <p>
           When called, this method executes the following steps:</p>
           <ol>
@@ -429,7 +415,7 @@
             <li> Run the following steps in parallel:
             <ol>
               <li>Resolve <var>p</var> with a <dfn>Sequence</dfn> that contains all
-              the <a>instrumentKey</a>s for the <a>PaymentInstrument</a>s
+              the <var>instrumentKey</var>s for the <a>PaymentInstrument</a>s
               contained in the collection.
             </ol>
             <li> Return <var>p</var></li>
@@ -437,7 +423,7 @@
       </section>
 
       <section>
-        <h2><dfn>has</dfn> method</h2>
+        <h2><dfn>has()</dfn> method</h2>
         <p>
           When called, this method executes the following steps:</p>
           <ol>
@@ -445,7 +431,7 @@
             <li> Run the following steps in parallel:
             <ol>
               <li> If the collection contains a <a>PaymentInstrument</a>
-              with a matching <a>instrumentKey</a>, resolve <var>p</var>
+              with a matching <var>instrumentKey</var>, resolve <var>p</var>
               with <b>true</b>.</li>
               <li> Otherwise, resolve <var>p</var> with <b>false</b>.</li>
             </ol>
@@ -454,7 +440,7 @@
       </section>
 
       <section>
-        <h2><dfn>set</dfn> method</h2>
+        <h2><dfn>set()</dfn> method</h2>
         <p>
           When called, this method executes the following steps:</p>
           <ol>
@@ -462,12 +448,12 @@
             <li> Run the following steps in parallel:
             <ol>
               <li> If the collection contains a <a>PaymentInstrument</a>
-              with a matching <a>instrumentKey</a>, replace it with
-              the <a>PaymentInstrument</a> in <dfn>details</dfn>.
+              with a matching <var>instrumentKey</var>, replace it with
+              the <a>PaymentInstrument</a> in <var>details</var>.
               <li> Otherwise, <a>PaymentInstrument</a>
-              insert the <a>PaymentInstrument</a> in <a>details</a>
+              insert the <a>PaymentInstrument</a> in <var>details</var>
               as a new member of the collection and associate it with the
-              key <a>instrumentKey</a>.
+              key <var>instrumentKey</var>.
               <li> Resolve <var>p</var>.</li>
             </ol>
             <li> Return <var>p</var></li>
@@ -522,11 +508,11 @@
           Promise&lt;void&gt;          set(DOMString walletKey, PaymentWallet details);
       };
       </pre>
-      <p>Where it appears, The <dfn>walletKey</dfn> parameter is
+      <p>Where it appears, The <dfn>walletKey</dfn> argument is
       a unique identifier for the wallet.</p>
 
       <section>
-        <h2><dfn>delete</dfn> method</h2>
+        <h2><dfn>delete()</dfn> method</h2>
         <p>
           When called, this method executes the following steps:</p>
           <ol>
@@ -534,7 +520,7 @@
             <li> Run the following steps in parallel:
             <ol>
               <li> If the collection contains a <a>PaymentWallet</a>
-              with a matching <a>walletKey</a>, remove it from
+              with a matching <var>walletKey</var>, remove it from
               the collection and resolve <var>p</var> with <b>true</b>.</li>
               <li> Otherwise, resolve <var>p</var> with <b>false</b>.</li>
             </ol>
@@ -543,7 +529,7 @@
       </section>
 
       <section>
-        <h2><dfn>get</dfn> method</h2>
+        <h2><dfn>get()</dfn> method</h2>
         <p>
           When called, this method executes the following steps:</p>
           <ol>
@@ -551,7 +537,7 @@
             <li> Run the following steps in parallel:
             <ol>
               <li> If the collection contains a <a>PaymentWallet</a>
-              with a matching <a>walletKey</a>, resolve <var>p</var>
+              with a matching <var>walletKey</var>, resolve <var>p</var>
               with that <a>PaymentWallet</a>.
               <li> Otherwise, reject <var>p</var> with a
               <a>DOMException</a> whose value is
@@ -562,7 +548,7 @@
       </section>
 
       <section>
-        <h2><dfn>keys</dfn> method</h2>
+        <h2><dfn>keys()</dfn> method</h2>
         <p>
           When called, this method executes the following steps:</p>
           <ol>
@@ -570,7 +556,7 @@
             <li> Run the following steps in parallel:
             <ol>
               <li>Resolve <var>p</var> with a sequence that contains all
-              the <a>walletKey</a>s for the <a>PaymentWallet</a>s
+              the <var>walletKey</var>s for the <a>PaymentWallet</a>s
               contained in the collection.
             </ol>
             <li> Return <var>p</var></li>
@@ -578,7 +564,7 @@
       </section>
 
       <section>
-        <h2><dfn>has</dfn> method</h2>
+        <h2><dfn>has()</dfn> method</h2>
         <p>
           When called, this method executes the following steps:</p>
           <ol>
@@ -586,7 +572,7 @@
             <li> Run the following steps in parallel:
             <ol>
               <li> If the collection contains a <a>PaymentWallet</a>
-              with a matching <a>walletKey</a>, resolve <var>p</var>
+              with a matching <var>walletKey</var>, resolve <var>p</var>
               with <b>true</b>.</li>
               <li> Otherwise, resolve <var>p</var> with <b>false</b>.</li>
             </ol>
@@ -595,7 +581,7 @@
       </section>
 
       <section>
-        <h2><dfn>set</dfn> method</h2>
+        <h2><dfn>set()</dfn> method</h2>
         <p>
           When called, this method executes the following steps:</p>
           <ol>
@@ -603,12 +589,12 @@
             <li> Run the following steps in parallel:
             <ol>
               <li> If the collection contains a <a>PaymentWallet</a>
-              with a matching <a>walletKey</a>, replace it with
-              the <a>PaymentWallet</a> in <a>details</a>.
+              with a matching <var>walletKey</var>, replace it with
+              the <a>PaymentWallet</a> in <var>details</var>.
               <li> Otherwise, <a>PaymentWallet</a>
-              insert the <a>PaymentWallet</a> in <a>details</a>
+              insert the <a>PaymentWallet</a> in <var>details</var>
               as a new member of the collection and associate it with the
-              key <a>walletKey</a>.
+              key <var>walletKey</var>.
               <li> Resolve <var>p</var>.</li>
             </ol>
             <li> Return <var>p</var></li>
@@ -646,7 +632,7 @@
         </dd>
       </dl>
     </section>
-    <section id="register-example">
+    <section id="register-example" class="informative">
       <h2>Registration Example</h2>
       <p>The following example shows how to register a payment
       handler:</p>
@@ -658,7 +644,7 @@
       <a>PaymentManager</a>),
       but this is likely to change.
       </p>
-      <pre class="example highlight" title=
+      <pre class="example js" title=
       "Payment Handler Registration">
         window.addEventListerner("DOMContentLoaded", async() =&gt; {
           const { registration } =
@@ -871,9 +857,8 @@
           This attribute a string that indicates the <a data-cite=
 							"!HTML5#origin">origin</a>
           of the <a>payee</a> web page. It MUST be formatted
-          according to the "<a href=
-			       "https://tools.ietf.org/html/rfc6454#section-6.1">Unicode
-            Serialization of an Origin</a>" algorithm defined in
+          according to the <a data-cite="!rfc6454#section-6.1">Unicode
+            Serialization of an Origin</a> algorithm defined in
           section 6.1 of [[!RFC6454]].
         </p>
       </section>
@@ -903,7 +888,7 @@
 	  This attribute indicates the total amount being requested
 	  for payment. It is initialized with a <a>structured
 	    clone</a> of the <a>total</a> field of the
-          <a>PaymentDetails</a> provided when the
+          <a>PaymentDetailsInit</a> provided when the
           corresponding <a>PaymentRequest</a> object was
           instantiated.
         </p>
@@ -1255,13 +1240,13 @@
         </ol>
       </section>
 
-      	<section id="post-example">
+      <section id="post-example" class="informative">
       <h2>Example of handling the <a>PaymentRequestEvent</a></h2>
       <p>This example shows how to write a service worker that
 	listens to the <a>PaymentRequestEvent</a>. When a
 	<a>PaymentRequestEvent</a> is received, the service worker opens a window in order
       to interact with the user.</p>
-      <pre class="example highlight" title=
+      <pre class="example js" title=
       "Handling the PaymentRequestEvent">
       self.addEventListener('paymentrequest', function(e) {
         e.respondWith(new Promise(function(resolve, reject) {
@@ -1288,9 +1273,9 @@
       page that is loaded into the <a>payment handler window</a> to
       implement the <em>basic card</em> scheme might look like the
       following:</p>
-      <pre class="example highlight" title=
+      <pre class="example html" title=
       "Simple Payment Handler Window">
-&lt;html&gt; &lt;body&gt; &lt;form id="form"&gt;
+&lt;form id="form"&gt;
 &lt;table&gt;
   &lt;tr&gt;&lt;th&gt;Cardholder Name:&lt;/th&gt;&lt;td&gt;&lt;input name="cardholderName"&gt;&lt;/td&gt;&lt;/tr&gt;
   &lt;tr&gt;&lt;th&gt;Card Number:&lt;/th&gt;&lt;td&gt;&lt;input name="cardNumber"&gt;&lt;/td&gt;&lt;/tr&gt;
@@ -1323,7 +1308,7 @@ window.addEventListener("message", function(e) {
     window.close();
   }
 });
-&lt;/script&gt; &lt;/body&gt; &lt;/html&gt;
+&lt;/script&gt;
     </pre>
     </section>
 
@@ -1403,18 +1388,18 @@ window.addEventListener("message", function(e) {
             assign it to
             <var>response</var>.<a data-lt="PaymentAppResponse.methodName">methodName</a>.
             </li>
-            <li>If <var>appResponse</var>.<a>details</a> is
+            <li>If <var>appResponse</var>.<var>details</var> is
             not present, run the <a>payment app failure
             algorithm</a> and terminate these steps.
             </li>
             <li>Create a <a>structured clone</a> of
-            <var>appResponse</var>.<a>details</a> and assign
-            it to <var>response</var>.<a>details</a>.
+            <var>appResponse</var>.<var>details</var> and assign
+            it to <var>response</var>.<var>details</var>.
             </li>
           </ol>
           <p>The following example shows how to respond to a
           payment request:</p>
-          <pre class="example highlight" title=
+          <pre class="example js" title=
           "Sending a Payment Response">
       paymentRequestEvent.respondWith(new Promise(function(accept,reject) {
         /* ... processing may occur here ... */

--- a/index.html
+++ b/index.html
@@ -229,7 +229,7 @@
             </li>
           </ul>
       <dt>Secure Contexts</dt>
-      <dd>The term <dfn data-cite="!secure-contexts#secure-context">secure context</dfn> is defined by the
+      <dd>The term <dfn data-cite="!SECURE-CONTEXTS#secure-context">secure context</dfn> is defined by the
       Secure Contexts specification [[!SECURE-CONTEXTS]].</dd>
       <dt>Service Workers</dt>
       <dd>The terms <dfn data-cite="!SERVICE-WORKERS#service-worker-concept">service worker</dfn>, <code><dfn data-cite="!SERVICE-WORKERS#service-worker-registration-concept">ServiceWorkerRegistration</dfn></code>, <code><dfn data-cite="!SERVICE-WORKERS#service-worker-global-scope">ServiceWorkerGlobalScope</dfn></code>, <dfn data-cite="!SERVICE-WORKERS#handle-functional-event-algorithm">handle functional event</dfn>, <dfn data-cite="!SERVICE-WORKERS#dfn-extend-lifetime-promises">extend lifetime promises</dfn>, and <dfn data-cite="!SERVICE-WORKERS#dfn-scope-url">scope URL</dfn> are defined in

--- a/index.html
+++ b/index.html
@@ -1116,8 +1116,8 @@
                 </li>
                 <li>Set the <a data-lt="PaymentRequestEvent.appRequest">appRequest</a> attribute of
                 <var>e</var> to a new <a>PaymentAppRequest</a>
-                instance, populated as described in <a href=
-                "#sec-app-request"></a>.
+                instance using the <a>MethodData Population Algorithm</a>
+		and the <a>Modifiers Population Algorithm</a>.
                 </li>
                 <li>Dispatch <var>e</var> to
                 <var>global</var>.</li>
@@ -1191,7 +1191,7 @@
           <var>url</var> argument.</li>
           <li>If the url parsing throws an exception, return a <a>Promise</a>
           rejected with that exception.</li>
-          <li>If url is about:blank, return a <a>Promise</a> rejected with
+          <li>If <var>url</var> is <code>about:blank</code>, return a <a>Promise</a> rejected with
           a <a>TypeError</a>.
           </li>
           <li>Let <var>promise</var> be a new <a>Promise</a>.

--- a/index.html
+++ b/index.html
@@ -280,7 +280,7 @@
       <li>When the merchant calls Payment Request API (e.g., when
       the user pushes a button on a checkout page), the user agent
       computes a list of matching payment handlers, comparing the
-      payment methods accepted by the user with those supported by
+      payment methods accepted by the merchant with those supported by
       registered payment handlers. For payment methods that support
       additional filtering, merchant and payment handler
       capabilities are compared as part of determining whether
@@ -758,7 +758,7 @@
     Request API, the user agent displays a list of matching origins
     for the user to make a selection. This specification includes a
     limited number of display requirements; most user experience
-    details are left to user agents.</p>
+    details are left to user agent implementers.</p>
     <section>
       <h3>Ordering of Payment Handlers</h3>
       <ul>
@@ -1070,7 +1070,7 @@
           <dt><code>respondWith</code> method</dt>
           <dd>
             This method is used by the payment handler to provide a
-            <a>PaymentAppResponse</a> when the payment successfully
+            <a>PaymentAppResponse</a> when user interaction successfully
             completes.
           </dd>
         </dl>
@@ -1189,8 +1189,8 @@
           Promise.</p>
           <p>If the Promise is rejected, the user agent MUST run
           the <dfn>payment app failure algorithm</dfn>. The exact
-          details of this algorithm is left for user agent
-          implementers to decide on. Acceptable behaviors include,
+          details of this algorithm are left to user agent
+          implementers. Acceptable behaviors include,
           but are not limited to:</p>
           <ul>
             <li>Letting the user try again, with the same payment

--- a/index.html
+++ b/index.html
@@ -245,7 +245,7 @@
       <dd>The terms <dfn>secure context</dfn> is defined by the
       Secure Contexts specification [[!POWERFUL-FEATURES]].</dd>
       <dt>Service Workers</dt>
-      <dd>The terms <dfn>service worker</dfn>, <dfn>ServiceWorkerRegistration</dfn>, <dfn>ServiceWorkerGlobalScope</dfn>, <dfn>handle functional event</dfn>, <dfn>extend lifetime promises</dfn>, and <dfn>scope URL</dfn> are defined in
+      <dd>The terms <dfn data-cite="!SERVICE-WORKERS#service-worker-concept">service worker</dfn>, <dfn data-cite="!SERVICE-WORKERS#dfn-service-worker-client">service worker client</dfn>, <code><dfn data-cite="!SERVICE-WORKERS#service-worker-registration-concept">ServiceWorkerRegistration</dfn></code>, <code><dfn data-cite="!SERVICE-WORKERS#service-worker-global-scope">ServiceWorkerGlobalScope</dfn></code>, <dfn data-cite="!SERVICE-WORKERS#handle-functional-event-algorithm">handle functional event</dfn>, <dfn data-cite="!SERVICE-WORKERS#dfn-extend-lifetime-promises">extend lifetime promises</dfn>, and <dfn data-cite="!SERVICE-WORKERS#dfn-scope-url">scope URL</dfn> are defined in
       [[!SERVICE-WORKERS]].</dd>
     </dl>
   </section>
@@ -1229,7 +1229,7 @@
               <li>If the navigation throws an exception, reject
 		<var>promise</var> with that exception and abort
 		these steps.</li>
-	       <li>If the origin of <var>newContext</var> is not the same as the <a>server worker client</a> origin associated with the payment handler, then:
+	       <li>If the origin of <var>newContext</var> is not the same as the <a>service worker client</a> origin associated with the payment handler, then:
               <ol>
                 <li>Reject <var>promise</var> with a <a>DOMException</a> whose name is "<a>SecurityError</a>".</li>
                 <li>Abort these steps.</li>

--- a/index.html
+++ b/index.html
@@ -141,7 +141,7 @@
       <dd>
         <p>A <a>user agent</a> MUST behave as described in this
         specification in order to be considered conformant. In this
-        specification, <a>user agent</a> means a <em>Web browser or
+        specification, <dfn>user agent</dfn>> means a <em>Web browser or
         other interactive user agent</em> as defined in
         [[!HTML5]].</p>
         <p>User agents MAY implement algorithms given in this
@@ -166,10 +166,13 @@
     specifications.</p>
     <dl>
       <dt>Payment Request API</dt>
-      <dd>The terms <dfn>PaymentRequest</dfn>,
+      <dd>The terms <dfn data-lt="payment method|payment methods">payment method</dfn>, <dfn>PaymentRequest</dfn>,
       <dfn>PaymentResponse</dfn>, and <dfn>user accepts the payment
       request algorithm</dfn> are defined by the Payment Request
       API specification [[!PAYMENT-REQUEST-API]].</dd>
+      <dt>Payment Method Identifiers</dt>
+      <dd>The terms <dfn data-lt="payment method identifier|payment method identifiers">payment method identifier</dfn> is defined by the Payment Method
+      Identifier specification [[!METHOD-IDENTIFIERS]].</dd>
       <dt>HTML5</dt>
       <dd>The terms <dfn>global object</dfn>,<dfn>origin</dfn>,
       <dfn>queue a task</dfn>, <dfn>browsing context</dfn>,
@@ -179,8 +182,24 @@
       settings object</dfn> are defined by [[!HTML5]].</dd>
       <dt>ECMA-262 6th Edition, The ECMAScript 2015 Language
       Specification</dt>
-      <dd>The term <dfn>Promise</dfn> is defined by
-      [[!ECMA-262-2015]].</dd>
+      <dd>
+          The terms <dfn data-cite=
+          "!ECMA-262-2015#sec-promise-objects">Promise</dfn>, <dfn data-cite=
+          "!ECMA-262-2015#sec-object-internal-methods-and-internal-slots">internal
+          slot</dfn>, <code><dfn data-cite=
+          "!ECMA-262-2015#sec-native-error-types-used-in-this-standard-typeerror">
+          TypeError</dfn></code>, and <code><dfn data-cite=
+          "!ECMA-262-2015#sec-json.stringify">JSON.stringify</dfn></code> are
+          defined by [[!ECMA-262-2015]].
+        <p>
+          The term <dfn data-lt=
+			"JSON-serialized|JSON-serializable">JSON-serialize</dfn> applied to
+          a given object means to run the algorithm specified by the original
+          value of the <a>JSON.stringify</a> function on the supplied object,
+          passing the supplied object as the sole argument, and return the
+          resulting string. This can throw an exception.
+        </p>
+      </dd>
       <dt>DOM4</dt>
       <dd>
         <p><dfn>DOMException</dfn> and the following DOMException
@@ -250,7 +269,7 @@
       worker</dfn>, <dfn>handle functional event</dfn>, <dfn>extend
       lifetime promises</dfn>, and <dfn data-lt=
       "scope url|scope urls">scope URL</dfn> are defined in
-      [[SERVICE-WORKERS]].</dd>
+      [[!SERVICE-WORKERS]].</dd>
     </dl>
   </section>
   <section id="model">
@@ -278,7 +297,7 @@
           of Instruments supported by the payment handler.</li>
         </ul>
       </li>
-      <li>When the merchant calls Payment Request API (e.g., when
+      <li>When the merchant (or other <dfn>payee</dfn>) calls Payment Request API (e.g., when
       the user pushes a button on a checkout page), the user agent
       computes a list of matching payment handlers, comparing the
       payment methods accepted by the merchant with those supported by
@@ -290,10 +309,10 @@
       displaying and grouping Instruments according to information
       (labels and icons) provided at registration or otherwise
       available from the Web app.</li>
-      <li>When the user selects an Instrument, the user agent fires the
-      paymentrequest event in the service worker whose registration
+      <li>When the user (the <dfn>payer</dfn>) selects an Instrument, the user agent fires the
+      <a>PaymentRequestEvent</a> in the service worker whose registration
       included the payment handler that provided that Instrument. The
-      paymentrequest event includes some information from the
+      <a>PaymentRequestEvent</a> includes some information from the
       PaymentRequest (defined in [[!PAYMENT-REQUEST-API]]) as well
       as additional information (e.g., origin and selected
       Instrument).</li>
@@ -322,12 +341,11 @@
     authentication, user interaction, and so on.</p>
   </section>
   <section id="registration">
-    <h2>Payment Handler Registration</h2>
+    <h2><dfn>Payment Handler</dfn> Registration</h2>
     <section>
-      <h3>Extensions to the <a>ServiceWorkerRegistration</a>
-      interface</h3>
+      <h3>Extensions to the ServiceWorkerRegistration interface</h3>
       <p>The Service Worker specification defines a
-      <code>ServiceWorkerRegistration</code> interface
+      <dfn>ServiceWorkerRegistration</dfn> interface
       [[!SERVICE-WORKERS]], which this specification extends.</p>
       <pre id="service-worker-registration-idl" class="idl">
         partial interface ServiceWorkerRegistration {
@@ -335,8 +353,8 @@
         };
       </pre>
     </section>
-    <section id="payment-manager">
-      <h2><a>PaymentManager</a> interface</h2>
+    <section data-dfn-for="PaymentManager">
+      <h3><dfn>PaymentManager</dfn> interface</h3>
       <pre id="payment-manager-idl" class="idl">
       interface PaymentManager {
         [SameObject] readonly attribute PaymentInstruments instruments;
@@ -344,7 +362,7 @@
       };
       </pre>
       <dl>
-        <dt><code>instruments</code> attribute</dt>
+        <dt><dfn>instruments</dfn> attribute</dt>
         <dd>
           This attribute allows manipulation of payment instruments
           associated with a payment handler. To be presented to the
@@ -354,7 +372,7 @@
           methods and required capabilities specified by the
           payment request.
         </dd>
-        <dt><code>wallets</code> attribute</dt>
+        <dt><dfn>wallets</dfn> attribute</dt>
         <dd>This attribute allows payment handlers to group payment
         instruments together and provide a name and icon for such a
         group (e.g., to group together "business account" payment
@@ -366,8 +384,8 @@
         users by the browser for selection.</dd>
       </dl>
     </section>
-    <section id="payment-instruments">
-      <h2><a>PaymentInstruments</a> interface</h2>
+    <section data-dfn-for="PaymentInstruments">
+      <h3><dfn>PaymentInstruments</dfn> interface</h3>
       <pre id="payment-instruments-idl" class="idl">
       interface PaymentInstruments {
           Promise&lt;boolean&gt;              delete(DOMString instrumentKey);
@@ -379,13 +397,13 @@
       };
       </pre>
       <p>The <a>PaymentInstruments</a> interface represents a collection of
-      payment instruments, each uniquely identified by an <a>instrumentKey</a>.
+      payment instruments, each uniquely identified by an <dfn>instrumentKey</dfn>.
       The <a>instrumentKey</a> identifier will be passed to the
       payment handler to indicate the <a>PaymentInstrument</a>
       selected by the user.</p>
       <dl>
 
-        <dt><code>delete</code> method</dt>
+        <dt><dfn>delete</dfn> method</dt>
         <dd>
           When called, this method executes the following steps:
           <ol>
@@ -401,7 +419,7 @@
           </ol>
         </dd>
 
-        <dt><code>get</code> method</dt>
+        <dt><dfn>get</dfn> method</dt>
         <dd>
           When called, this method executes the following steps:
           <ol>
@@ -419,7 +437,7 @@
           </ol>
         </dd>
 
-        <dt><code>keys</code> method</dt>
+        <dt><dfn>keys</dfn> method</dt>
         <dd>
           When called, this method executes the following steps:
           <ol>
@@ -434,7 +452,7 @@
           </ol>
         </dd>
 
-        <dt><code>has</code> method</dt>
+        <dt><dfn>has</dfn> method</dt>
         <dd>
           When called, this method executes the following steps:
           <ol>
@@ -450,7 +468,7 @@
           </ol>
         </dd>
 
-        <dt><code>set</code> method</dt>
+        <dt><dfn>set</dfn> method</dt>
         <dd>
           When called, this method executes the following steps:
           <ol>
@@ -479,9 +497,9 @@
 
 
     </section>
-    <section id="payment-instrument">
-      <h2><a>PaymentInstrument</a> dictionary</h2>
-      <pre id="payment-instrumnt-idl" class="idl">
+    <section data-dfn-for="PaymentInstrument">
+      <h3><dfn>PaymentInstrument</dfn> dictionary</h3>
+      <pre id="payment-instrument-idl" class="idl">
       dictionary PaymentInstrument {
         required DOMString name;
         sequence&lt;ImageObjects&gt; icons;
@@ -490,25 +508,23 @@
       };
       </pre>
       <dl>
-        <dt><code>name</code> member</dt>
+        <dt><dfn id="payment-instrument-name">name</dfn> member</dt>
         <dd>The <code>name</code> member is a string that
         represents the label for this payment Instrument as it is
         usually displayed to the user.</dd>
-        <dt><code>icons</code> member</dt>
+        <dt><dfn>icons</dfn> member</dt>
         <dd>The <code>icons</code> member is an array of image
         objects that can serve as iconic representations of the
         payment Instrument when presented to the user for
         selection.</dd>
-        <dt><code>enabledMethods</code> member</dt>
+        <dt><dfn id="payment-instrument-enabled-methods">enabledMethods</dfn> member</dt>
         <dd>
-          The <dfn id=
-          "payment-instrument-enabled-methods"><code>enabledMethods</code></dfn>
+          The <code>enabledMethods</code>
           member lists the <a>payment method identifiers</a> of the
           payment methods enabled by this Instrument.
         </dd>
-        <dt><code>capabilities</code> member</dt>
-        <dd>The <dfn id=
-        "payment-instrument-capabilities"><code>capabilities</code></dfn>
+        <dt><dfn id="payment-instrument-capabilities">capabilities</dfn> member</dt>
+        <dd>The <code>capabilities</code>
         member contains a list of payment-method-specific
         capabilities that this payment handler is capable of
         supporting for this Instrument. For example, for the
@@ -518,30 +534,30 @@
         <code>supportedTypes</code>.</dd>
       </dl>
     </section>
-    <section id="payment-wallets">
-      <h2><a>PaymentWallets</a> interface</h2>
+    <section data-dfn-for="PaymentWallets">
+      <h3><dfn>PaymentWallets</dfn> interface</h3>
       <pre id="payment-wallets-idl" class="idl">
       interface PaymentWallets {
           Promise&lt;boolean&gt;              delete(DOMString walletKey);
-          Promise&lt;WalletDetails&gt; get(DOMString walletKey);
+          Promise&lt;PaymentWallet&gt; get(DOMString walletKey);
           Promise&lt;sequence&lt;DOMString&gt;&gt;  keys();
           Promise&lt;boolean&gt;              has(DOMString walletKey);
           Promise&lt;void&gt;                 set(DOMString walletKey,
-                                              WalletDetails details);
+                                              PaymentWallet details);
       };
       </pre>
       <p>Where it appears, The <code>walletKey</code> parameter is
       a unique identifier for the wallet.</p>
       <dl>
 
-        <dt><code>delete</code> method</dt>
+        <dt><dfn>delete</dfn> method</dt>
         <dd>
           When called, this method executes the following steps:
           <ol>
             <li> Let <var>p</var> be a new promise.</li>
             <li> Run the following steps in parallel:</li>
             <ol>
-              <li> If the collection contains a <a>WalletDetails</a>
+              <li> If the collection contains a <a>PaymentWallet</a>
               with a matching <code>walletKey</code>, remove it from
               the collection and resolve <var>p</var> with <b>true</b>.</li>
               <li> Otherwise, resolve <var>p</var> with <b>false</b>.</li>
@@ -550,16 +566,16 @@
           </ol>
         </dd>
 
-        <dt><code>get</code> method</dt>
+        <dt><dfn>get</dfn> method</dt>
         <dd>
           When called, this method executes the following steps:
           <ol>
             <li> Let <var>p</var> be a new promise.</li>
             <li> Run the following steps in parallel:</li>
             <ol>
-              <li> If the collection contains a <a>WalletDetails</a>
+              <li> If the collection contains a <a>PaymentWallet</a>
               with a matching <code>walletKey</code>, resolve <var>p</var>
-              with that <a>WalletDetails</a>.
+              with that <a>PaymentWallet</a>.
               <li> Otherwise, reject <var>p</var> with a
               <a>DOMException</a> whose value is
               "<a>NotFoundError</a>".
@@ -568,7 +584,7 @@
           </ol>
         </dd>
 
-        <dt><code>keys</code> method</dt>
+        <dt><dfn>keys</dfn> method</dt>
         <dd>
           When called, this method executes the following steps:
           <ol>
@@ -576,21 +592,21 @@
             <li> Run the following steps in parallel:</li>
             <ol>
               <li>Resolve <var>p</var> with a sequence that contains all
-              the <code>walletKey</code>s for the <a>WalletDetails</a>s
+              the <code>walletKey</code>s for the <a>PaymentWallet</a>s
               contained in the collection.
             </ol>
             <li> Return <var>p</var></li>
           </ol>
         </dd>
 
-        <dt><code>has</code> method</dt>
+        <dt><dfn>has</dfn> method</dt>
         <dd>
           When called, this method executes the following steps:
           <ol>
             <li> Let <var>p</var> be a new promise.</li>
             <li> Run the following steps in parallel:</li>
             <ol>
-              <li> If the collection contains a <a>WalletDetails</a>
+              <li> If the collection contains a <a>PaymentWallet</a>
               with a matching <code>walletKey</code>, resolve <var>p</var>
               with <b>true</b>.</li>
               <li> Otherwise, resolve <var>p</var> with <b>false</b>.</li>
@@ -599,18 +615,18 @@
           </ol>
         </dd>
 
-        <dt><code>set</code> method</dt>
+        <dt><dfn>set</dfn> method</dt>
         <dd>
           When called, this method executes the following steps:
           <ol>
             <li> Let <var>p</var> be a new promise.</li>
             <li> Run the following steps in parallel:</li>
             <ol>
-              <li> If the collection contains a <a>WalletDetails</a>
+              <li> If the collection contains a <a>PaymentWallet</a>
               with a matching <code>walletKey</code>, replace it with
-              the <a>WalletDetails</a> in <code>details</code>.
-              <li> Otherwise, <a>WalletDetails</a>
-              insert the <a>WalletDetails</a> in <code>details</code>
+              the <a>PaymentWallet</a> in <code>details</code>.
+              <li> Otherwise, <a>PaymentWallet</a>
+              insert the <a>PaymentWallet</a> in <code>details</code>
               as a new member of the collection and associate it with the
               key <code>walletKey</code>.
               <li> Resolve <var>p</var>.</li>
@@ -622,28 +638,28 @@
       </dl>
 
     </section>
-    <section id="wallet-details">
-      <h2><a>WalletDetails</a> dictionary</h2>
-      <pre id="wallet-details-idl" class="idl">
-      dictionary WalletDetails {
+    <section data-dfn-for="PaymentWallet">
+      <h3><dfn>PaymentWallet</dfn> dictionary</h3>
+      <pre id="payment-wallet-idl" class="idl">
+      dictionary PaymentWallet {
           required DOMString name;
           sequence&lt;ImageObject&gt; icons;
           required sequence&lt;DOMString&gt; instrumentKeys;
       };
       </pre>
       <dl>
-        <dt><code>name</code> member</dt>
+        <dt><dfn id="payment-wallet-name">name</dfn> member</dt>
         <dd>The <code>name</code> member is a string that
         represents the label for this wallet as it is usually
         displayed to the user.</dd>
-        <dt><code>icons</code> member</dt>
+        <dt><dfn id="payment-wallet-icons">icons</dfn> member</dt>
         <dd>The <code>icons</code> member is an array of image
         objects that can serve as iconic representations of the
         wallet when presented to the user for selection.</dd>
-        <dt><code>instrumentKeys</code> member</dt>
+        <dt><dfn id="payment-wallet-instrument-keys">instrumentKeys</dfn> member</dt>
         <dd>The <code>instrumentKeys</code> member is a
         list of <code>instrumentKey</code>s from
-        <a>PaymentManager</a>.<code>instruments</code>,
+        <code>PaymentManager.instruments</code>,
         indicating which <a>PaymentInstrument</a> objects are associated
         with this <a>Wallet</a>, and should be displayed as being "contained in"
         the wallet. While it is not generally good practice, there is no
@@ -661,7 +677,7 @@
       Issue 94</a>. The means for code requesting permission to handle
       payments is not yet defined. The code below is based on one
       potential model (a <code>requestPermission()</code> method on the
-      <a>PaymentManager</a>),
+      <code>PaymentManager</code>),
       but this is likely to change.
       </p>
       <pre class="example highlight" title=
@@ -831,8 +847,8 @@
       for display purposes.</p>
       <p>To enable developers to build payment apps in a variety of
       ways, we decouple the registration (and subsequent display)
-      of Instruments from how payment handlers respond to
-      paymentrequest events. However, the user agent is responsible
+      of Instruments from how payment handlers respond to a
+      <a>PaymentRequestEvent</a>. However, the user agent is responsible
       for communicating the user's selection in the event.</p>
     </section>
     <section>
@@ -856,11 +872,11 @@
   <section id="invocation">
     <h2>Payment Handler Invocation, Display and Response</h2>
     <p>Once the user has selected an Instrument, the user agent fires a
-    <a>paymentrequest event</a> with a Payment App Request, and
-    uses the subsequent Payment App Response to create a
+    <a>PaymentRequestEvent</a> with a <a>PaymentAppRequest</a>, and
+    uses the subsequent <a>PaymentAppResponse</a> to create a
     PaymentReponse for [[!PAYMENT-REQUEST-API]].</p>
-    <section id="sec-app-request">
-      <h2><a>PaymentAppRequest</a> interface</h2>
+    <section data-dfn-for="PaymentAppRequest">
+      <h2><dfn>PaymentAppRequest</dfn> interface</h2>
       <pre class="idl">
       interface PaymentAppRequest {
         readonly attribute DOMString origin;
@@ -872,9 +888,10 @@
       };
       </pre>
       <dl>
-        <dt><dfn>origin</dfn> attribute</dt>
+        <dt><dfn>origin<dfn> attribute</dt>
         <dd>
-          This attribute a string that indicates the <a>origin</a>
+          This attribute a string that indicates the <a data-cite=
+          "!HTML5#origin">origin</a>
           of the <a>payee</a> web page. It MUST be formatted
           according to the "<a href=
           "https://tools.ietf.org/html/rfc6454#section-6.1">Unicode
@@ -1028,18 +1045,18 @@
     </section>
     <section>
       <h3>Invocation</h3>
-      <section>
+      <section data-dfn-for="ServiceWorkerGlobalScope">>
         <h3>Extension to <code>ServiceWorkerGlobalScope</code></h3>
-        <p>The Service Worker specification defines a
-        <code>ServiceWorkerGlobalScope</code> interface
-        [[!SERVICE-WORKERS]], which this specification extends.</p>
+        <p>The Service Worker specification [[!SERVICE-WORKERS]] defines a
+          <dfn>ServiceWorkerGlobalScope</dfn> interface,
+	  which this specification extends.</p>
         <pre class="idl">
         partial interface ServiceWorkerGlobalScope {
           attribute EventHandler onpaymentrequest;
         };
       </pre>
         <dl>
-          <dt><code>onpaymentrequest</code> attribute</dt>
+          <dt><dfn>onpaymentrequest</dfn> attribute</dt>
           <dd>
             The <code>onpaymentrequest</code> attribute is an
             <a>event handler</a> whose corresponding <a>event
@@ -1047,12 +1064,12 @@
           </dd>
         </dl>
         <p>The <a>PaymentRequestEvent</a> interface represents a
-        received <a>payment request</a>.</p>
+        received <a>PaymentRequest</a>.</p>
       </section>
-      <section>
-        <h3>The <code>paymentrequest</code> Event</h3>
-        <p>The <a>PaymentRequestEvent</a> represents a received
-        <a>payment request</a>.</p>
+    <section data-dfn-for="PaymentRequestEvent">
+        <h3>The <dfn>PaymentRequestEvent</dfn></h3>
+        <p>The <code>PaymentRequestEvent</code> represents a received
+        <a>PaymentRequest</a>.</p>
         <pre class="idl">
       [Exposed=ServiceWorker]
       interface PaymentRequestEvent : ExtendableEvent {
@@ -1060,23 +1077,20 @@
         Promise&lt;WindowClient&gt; openWindow(USVString url);
         void respondWith(Promise&lt;PaymentAppResponse&gt;appResponse);
       };
-      </pre>
-        <section>
-          <h3><dfn>appRequest</dfn> attribute</h3>
-          <p>This attribute contains the <a>PaymentAppRequest</a>
-          associated with this <a>payment request</a>.</p>
-        </section>
-        <section>
-          <h3><dfn>openWindow()</dfn> method</h3>
-          <p>This method is used by the payment handler to show a
+	</pre>
+	<dl>
+	  <dt><dfn id="appRequest">appRequest</dfn> attribute</dt>
+          <dd>This attribute contains the <a>PaymentAppRequest</a>
+          associated with this <a>PaymentRequest</a>.</dd>
+          <dt><dfn>openWindow()</dfn> method</dt>
+          <dd>This method is used by the payment handler to show a
           window to the user. When called, it runs the <a>open window
-          algorithm</a>.</p>
-        </section>
-        <section>
-          <h3><dfn>respondWith()</dfn> method</h3>
-          <p>This method is used by the payment handler to provide
+          algorithm</a>.</dd>
+          <dt><dfn>respondWith()</dfn> method</dt>
+          <dd>This method is used by the payment handler to provide
           a <a>PaymentAppResponse</a> when the payment successfully
-          completes.</p>
+            completes.</dd>
+	</dl>
         </section>
         <section>
           <h3>Internal Slots</h3>
@@ -1092,7 +1106,7 @@
               <td><dfn>[[\windowClient]]</dfn></td>
               <td>null</td>
               <td>
-                The currently active <a>WindowClient</a>. This is
+                The currently active <dfn>WindowClient</dfn>. This is
                 set if a payment handler is currently showing a
                 window to the user. Otherwise, it is null.
               </td>
@@ -1100,9 +1114,9 @@
           </table>
         </section>
         <section>
-          <h3>Handling a payment request event</h3>
-          <p>Upon receiving a <a>payment request</a> by way of
-          <a data-cite="!payment-request#show-method">PaymentRequest.show()</a> and subsequent user
+          <h3>Handling a PaymentRequestEvent</h3>
+          <p>Upon receiving a <a>PaymentRequest</a> by way of
+          <a data-cite="!PAYMENT-REQUEST-API#show-method">PaymentRequest.show()</a> and subsequent user
           selection of a payment handler, the <a>user agent</a>
           MUST run the following steps:</p>
           <ol>
@@ -1112,7 +1126,7 @@
             </li>
             <li>If <var>registration</var> is not found, reject the
             <a>Promise</a> that was created by
-            <a data-cite="!payment-request#show-method">PaymentRequest.show()</a> with a
+            <a data-cite="!PAYMENT-REQUEST-API#show-method">PaymentRequest.show()</a> with a
             <a>DOMException</a> whose value
             "<a>InvalidStateError</a>" and terminate these steps.
             </li>
@@ -1130,7 +1144,7 @@
                 which does not bubble, cannot be canceled, and has
                 no default action.
                 </li>
-                <li>Set the <a>appRequest</a> attribute of
+                <li>Set the <a href="#apprequest">appRequest</a> attribute of
                 <var>e</var> to a new <a>PaymentAppRequest</a>
                 instance, populated as described in <a href=
                 "#sec-app-request"></a>.
@@ -1141,10 +1155,10 @@
                 lifetime promises</a> of <var>e</var> to resolve.
                 </li>
                 <li>If the <a>payment handler</a> has not provided
-                a <a>payment app response</a> as described in
+                a <a>PaymentAppResponse</a> as described in
                 <a href="#sec-payment-app-response"></a>, reject
                 the <a>Promise</a> that was created by
-                < data-cite="!payment-request#show-method">PaymentRequest.show()</a> with a
+                < data-cite="!PAYMENT-REQUEST-API#show-method">PaymentRequest.show()</a> with a
                 <a>DOMException</a> whose value
                 "<a>OperationError</a>".
                 </li>
@@ -1173,22 +1187,22 @@
         or requiring user interaction.</li>
       </ul>
       <p>A <a>payment handler</a> that requires visual display and user
-      interaction, may call <a>openWindow()</a> to display a page to the
+      interaction, may call openWindow() to display a page to the
       user.</p>
 
       <p class="note"> Since user agents
-      know that this method is connected to the payment request
-      event, they SHOULD render the window in a way that is
+	know that this method is connected to the <a>PaymentRequestEvent</a>,
+	they SHOULD render the window in a way that is
       consistent with the flow and not confusing to the user.
       The resulting window client is bound to the tab/window
-      that initiated the <a>payment request</a>. A single
+      that initiated the <a>PaymentRequest</a>. A single
       <a>payment handler</a> SHOULD NOT be allowed to open more
       than one client window using this method.</p>
 
       <section>
         <h3><dfn>Open Window Algorithm</dfn></h3>
         <p class="issue" data-number="115">This algorithm is <i>very</i> similar to
-        the <a data-cite="!service-workers#clients-openwindow">
+        the <a data-cite="!SERVICE-WORKERS#clients-openwindow">
         Open Window Algorithm</a> in the Service Workers
         specification. Should we refer to the Service Workers
         specification instead of copying their steps?</p>
@@ -1197,10 +1211,10 @@
           <a>PaymentRequestEvent</a>.
           </li>
           <li>Let <var>request</var> be the <a>PaymentRequest</a>
-          that triggered this payment request event.
+          that triggered this <a>PaymentRequestEvent</a>.
           </li>
-          <li>If <var>request</var>.<a data-cite="!payment-request#dfn-state-1">[[\state]]</a> is not
-          "<a data-cite="!payment-request#dfn-interactive">interactive</a>", then return a <a>Promise</a> rejected with a <a>
+          <li>If <var>request</var>.<a data-cite="!PAYMENT-REQUEST-API#dfn-state-1">[[\state]]</a> is not
+          "<a data-cite="!PAYMENT-REQUEST-API#dfn-interactive">interactive</a>", then return a <a>Promise</a> rejected with a <a>
             DOMException</a> whose name is
             "<a>InvalidStateError</a>".
           </li>
@@ -1224,7 +1238,7 @@
               <var>promise</var> with that exception and abort
               these steps.</li>
               <li>If the origin of <var>newContext</var> is not the same as the
-              <var>event</var>.<a>appRequest</a>.<a href=
+              <var>event</var>.<a href="#appRequest">appRequest</a>.<a href=
               "#dom-paymentapprequest-origin">origin</a>, then:
                 <ol>
                   <li>Reject <var>promise</var> with a <a>DOMException</a> whose name is "<a>SecurityError</a>".</li>
@@ -1232,7 +1246,7 @@
                 </ol>
               </li>
               <li>Let <var>client</var> be the result of running the
-              <a data-cite="!service-workers#capture-windowclient-algorithm">
+              <a data-cite="!SERVICE-WORKERS#capture-windowclient-algorithm">
                 capture window client</a> algorithm with <var>newContext</var> as the
                 argument.
               </li>
@@ -1240,7 +1254,7 @@
               not null, then:
                 <ol>
                   <li>If
-                  <var>event</var>.<a>[[\windowClient]]</a>.<a data-cite="!service-workers#client-visibilitystate-attribute">visibilityState</a>
+                  <var>event</var>.<a>[[\windowClient]]</a>.<a data-cite="!SERVICE-WORKERS#client-visibilitystate-attribute">visibilityState</a>
                   is not "unloaded", reject <var>promise</var> with
                   a <a>DOMException</a> whose name is
                   "<a>InvalidStateError</a>" and abort these steps.
@@ -1258,9 +1272,9 @@
         </ol>
       </section>
     </section>
-    <section id="sec-payment-app-response">
-      <h2><a>PaymentAppResponse</a> dictionary</h2>
-      The <a>payment app response</a>
+    <section data-dfn-for="PaymentAppResponse">
+      <h2><dfn>PaymentAppResponse</dfn> dictionary</h2>
+      The PaymentAppResponse
       is conveyed using the following dictionary:
       <pre class="idl">
       dictionary PaymentAppResponse {
@@ -1269,15 +1283,15 @@
       };
     </pre>
       <dl>
-        <dt><code>methodName</code> attribute</dt>
+        <dt><dfn>methodName</dfn> attribute</dt>
         <dd>
           The <a>payment method identifier</a> for the <a>payment
           method</a> that the user selected to fulfil the
           transaction.
         </dd>
-        <dt><code>details</code> attribute</dt>
+        <dt><dfn>details</dfn> attribute</dt>
         <dd>
-          A <a>JSON-serializable object</a> that provides a
+          A <a>JSON-serializable</a> object that provides a
           <a>payment method</a> specific message used by the
           merchant to process the transaction and determine
           successful fund transfer.
@@ -1301,7 +1315,7 @@
             <li>Letting the user try again, with the same payment
             handler or with a different one.</li>
             <li>Rejecting the Promise that was created by
-            <a data-cite="!payment-request#show-method">PaymentRequest.show()</a>.</li>
+            <a data-cite="!PAYMENT-REQUEST-API#show-method">PaymentRequest.show()</a>.</li>
           </ul>
           <p>If this Promise is successfully resolved, the user
           agent MUST run the <a>user accepts the payment request
@@ -1365,12 +1379,12 @@
       <h3>Example of handling the <code>paymentrequest</code>
       event</h3>
       <p>This example shows how to write a service worker that
-      listens to the paymentrequest event. When a payment request
-      event is received, the service worker opens a window in order
+	listens to the <a>PaymentRequestEvent</a>. When a
+	<a>PaymentRequestEvent</a> is received, the service worker opens a window in order
       to interact with the user.</p>
       <pre class="example highlight" title=
-      "Handling the paymentrequest event" id=
-      "example-paymentrequest-event">
+      "Handling the PaymentRequestEvent" id=
+      "example-paymentrequestevent">
       self.addEventListener('paymentrequest', function(e) {
         e.respondWith(new Promise(function(resolve, reject) {
           self.addEventListener('message', listener = function(e) {

--- a/index.html
+++ b/index.html
@@ -232,7 +232,7 @@
       <dd>The term <dfn data-cite="!SECURE-CONTEXTS#secure-context">secure context</dfn> is defined by the
       Secure Contexts specification [[!SECURE-CONTEXTS]].</dd>
       <dt>Service Workers</dt>
-      <dd>The terms <dfn data-cite="!SERVICE-WORKERS#service-worker-concept">service worker</dfn>, <code><dfn data-cite="!SERVICE-WORKERS#service-worker-registration-concept">ServiceWorkerRegistration</dfn></code>, <code><dfn data-cite="!SERVICE-WORKERS#service-worker-global-scope">ServiceWorkerGlobalScope</dfn></code>, <dfn data-cite="!SERVICE-WORKERS#handle-functional-event-algorithm">handle functional event</dfn>, <dfn data-cite="!SERVICE-WORKERS#dfn-extend-lifetime-promises">extend lifetime promises</dfn>, and <dfn data-cite="!SERVICE-WORKERS#dfn-scope-url">scope URL</dfn> are defined in
+      <dd>The terms <dfn data-cite="!SERVICE-WORKERS#service-worker-concept">service worker</dfn>, <dfn data-cite="!SERVICE-WORKERS#dfn-service-worker-client">service worker client</dfn>, <code><dfn data-cite="!SERVICE-WORKERS#service-worker-registration-concept">ServiceWorkerRegistration</dfn></code>, <code><dfn data-cite="!SERVICE-WORKERS#service-worker-global-scope">ServiceWorkerGlobalScope</dfn></code>, <dfn data-cite="!SERVICE-WORKERS#handle-functional-event-algorithm">handle functional event</dfn>, <dfn data-cite="!SERVICE-WORKERS#dfn-extend-lifetime-promises">extend lifetime promises</dfn>, and <dfn data-cite="!SERVICE-WORKERS#dfn-scope-url">scope URL</dfn> are defined in
       [[!SERVICE-WORKERS]].</dd>
     </dl>
   </section>
@@ -1302,7 +1302,9 @@
           });
         }));
       });
-    </pre>
+      </pre>
+      	  <p class="issue"><a href="https://github.com/w3c/webpayments-payment-apps-api/issues/128">Issue 128</a>: The Web Payments Working Group plans to revisit these two examples.</p>
+
       <p>Using the simple scheme described above, a trivial HTML
       page that is loaded into the <a>payment handler window</a> to
       implement the <em>basic card</em> scheme might look like the
@@ -1343,7 +1345,7 @@ window.addEventListener("message", function(e) {
   }
 });
 &lt;/script&gt;
-    </pre>
+      </pre>
     </section>
 
     </section>
@@ -1448,7 +1450,7 @@ window.addEventListener("message", function(e) {
            }
         });
       });
-    </pre>
+	  </pre>
           <p class="note">[[!PAYMENT-REQUEST-API]] defines an
           <a>ID</a> that parties in the
           ecosystem (including payment app providers and payees)

--- a/index.html
+++ b/index.html
@@ -857,7 +857,8 @@
       <h2><dfn>PaymentAppRequest</dfn> interface</h2>
       <pre class="idl">
       interface PaymentAppRequest {
-        readonly attribute DOMString origin;
+        readonly attribute DOMString topLevelOrigin;
+        readonly attribute DOMString paymentRequestOrigin;
         readonly attribute DOMString id;
         readonly attribute FrozenArray&lt;PaymentMethodData&gt; methodData;
         readonly attribute PaymentItem total;
@@ -866,15 +867,22 @@
       };
       </pre>
       <section>
-	<h2><dfn>origin</dfn> attribute</h2>
+	<h2><dfn>topLevelOrigin</dfn> attribute</h2>
         <p>
           This attribute a string that indicates the <a data-cite=
 							"!HTML5#origin">origin</a>
-          of the <a>payee</a> web page. It MUST be formatted
+          of the top level <a>payee</a> web page. It MUST be formatted
           according to the "<a href=
 			       "https://tools.ietf.org/html/rfc6454#section-6.1">Unicode
             Serialization of an Origin</a>" algorithm defined in
           section 6.1 of [[!RFC6454]].
+        </p>
+      </section>
+      <section>
+	<h2><dfn>paymentRequestOrigin</dfn> attribute</h2>
+        <p>
+          If a <a>PaymentRequest</a> is initiated within an iframe
+	  whose <a data-cite="!HTML5#origin">origin</a> differs from <a>topLevelOrigin</a>, this attribute indicates the iframe origin. It MUST be formatted according to the "<a href="https://tools.ietf.org/html/rfc6454#section-6.1">Unicode Serialization of an Origin</a>" algorithm defined in section 6.1 of [[!RFC6454]].
         </p>
       </section>
       <section>
@@ -1219,15 +1227,8 @@
               <li><a data-cite="!whatwg-html#navigate">Navigate</a> <var>newContext</var> to <var>url</var>,
               with exceptions enabled and replacement enabled.</li>
               <li>If the navigation throws an exception, reject
-              <var>promise</var> with that exception and abort
+		<var>promise</var> with that exception and abort
               these steps.</li>
-              <li>If the origin of <var>newContext</var> is not the same as the
-              <var>event</var>.<a data-lt="PaymentRequestEvent.appRequest">appRequest</a>.<a data-lt="PaymentAppRequest.origin">origin</a>, then:
-                <ol>
-                  <li>Reject <var>promise</var> with a <a>DOMException</a> whose name is "<a>SecurityError</a>".</li>
-                  <li>Abort these steps.</li>
-                </ol>
-              </li>
               <li>Let <var>client</var> be the result of running the
               <a data-cite="!SERVICE-WORKERS#capture-windowclient-algorithm">
                 capture window client</a> algorithm with <var>newContext</var> as the


### PR DESCRIPTION
Per task force discussion about origin:
 https://www.w3.org/2017/04/04-apps-minutes#item01

Also updated open window algorithm, which referred to the wrong origin.
Now checks that window origin same as payment app service worker client origin.
