### PR TITLE
Fix to prevent duplicate ids by respec

### DIFF
--- a/index.html
+++ b/index.html
@@ -976,7 +976,7 @@
             <li>Return <var>p</var>
             </li>
           </ol>
-          <p class="issue" title="Clear()" data-number="129"></p>
+          <p class="issue" title="Clear()">See <a href="https://github.com/w3c/webpayments-payment-handler/issues/129">issue 129</a>.</p>
         </section>
       </section>
       <section data-dfn-for="PaymentWallet" data-link-for="PaymentWallet">
@@ -1204,8 +1204,8 @@
           cards the origin knows about.
           </li>
         </ul>
-        <p class="issue" title="Display" data-number="98">
-          There has been push-back to always requiring display of instruments
+        <p class="issue" title="Display">
+          In <a href="https://github.com/w3c/webpayments-payment-handler/issues/98">issue 98</a> there has been push-back to always requiring display of instruments
           (e.g., on a mobile devices). User agents can incrementally show
           instruments. Or user agents can return an empty instrumentKey and it
           becomes the payment app's responsibility to display instruments to
@@ -1254,8 +1254,8 @@
           eliminating an extra click (first open the payment app then select
           the Instrument).
         </p>
-        <p class="issue" title="selection" data-number="98">
-          Should we require that, if displayed, individual instruments must be
+        <p class="issue" title="selection">
+          Again related to <a href="https://github.com/w3c/webpayments-payment-handler/issues/98">issue 98</a>: Should we require that, if displayed, individual instruments must be
           selectable? Or should we allow flexibility that instruments may be
           displayed, but selecting any one invokes all registered payment
           handlers? One idea that has been suggested: the user agent (e.g., on


### PR DESCRIPTION
If you reference an issue mulitple times in the spec, for example:

<p class="issue" data-number="98"></p>

respec generates duplicate ids. So this edit removes that construct
in favor of some explicit links.