### PR TITLE
Add a constructor of PaymentRequestEvent and PaymentRequestEventInit.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1305,7 +1305,7 @@
           <a>PaymentRequest</a>.
         </p>
         <pre class="idl">
-        [Exposed=ServiceWorker]
+        [Constructor(DOMString type, PaymentRequestEventInit eventInitDict), Exposed=ServiceWorker]
         interface PaymentRequestEvent : ExtendableEvent {
           readonly attribute DOMString topLevelOrigin;
           readonly attribute DOMString paymentRequestOrigin;
@@ -1316,6 +1316,16 @@
           readonly attribute DOMString instrumentKey;
           Promise&lt;WindowClient&gt; openWindow(USVString url);
           void respondWith(Promise&lt;PaymentAppResponse&gt;appResponse);
+        };
+
+        dictionary PaymentRequestEventInit : ExtendableEventInit {
+          DOMString topLevelOrigin;
+          DOMString paymentRequestOrigin;
+          DOMString paymentRequestId;
+          sequence&lt;PaymentMethodData&gt; methodData;
+          PaymentItem total;
+          sequence&lt;PaymentDetailsModifier&gt; modifiers;
+          DOMString instrumentKey;
         };
       </pre>
         <section>

--- a/index.html
+++ b/index.html
@@ -1304,17 +1304,7 @@
           The <a>PaymentRequestEvent</a> represents a received
           <a>PaymentRequest</a>.
         </p>
-        <pre class="idl no-link-warnings">
-        dictionary PaymentRequestEventInit : ExtendableEventInit {
-          USVString topLevelOrigin;
-          USVString paymentRequestOrigin;
-          DOMString paymentRequestId;
-          sequence&lt;PaymentMethodData&gt; methodData;
-          PaymentItem total;
-          sequence&lt;PaymentDetailsModifier&gt; modifiers;
-          DOMString instrumentKey;
-        };
-
+        <pre class="idl">
         [Constructor(DOMString type, PaymentRequestEventInit eventInitDict), Exposed=ServiceWorker]
         interface PaymentRequestEvent : ExtendableEvent {
           readonly attribute USVString topLevelOrigin;
@@ -1441,11 +1431,29 @@
           permission either at installation or when the payment app is first
           invoked.
         </p>
-        <p class="issue" title="DOM Events compatibility" data-number="119">
-          For DOM events compatibility, need to add a constructor, and the
-          members of the corresponding dictionary need to match the attributes
-          of the event.
-        </p>
+        <section data-dfn-for="PaymentRequestEventInit">
+          <h2>
+            <dfn>PaymentRequestEventInit</dfn> dictionary
+          </h2>
+          <p>
+            The <dfn>topLevelOrigin</dfn>, <dfn>paymentRequestOrigin</dfn>,
+            <dfn>paymentRequestId</dfn>, <dfn> methodData</dfn>,
+            <dfn>total</dfn>, <dfn> modifiers</dfn>, and
+            <dfn>instrumentKey</dfn> members share their definitions with
+            those defined for <a>PaymentRequestEvent</a>
+          </p>
+          <pre class="idl">
+            dictionary PaymentRequestEventInit : ExtendableEventInit {
+              USVString topLevelOrigin;
+              USVString paymentRequestOrigin;
+              DOMString paymentRequestId;
+              sequence&lt;PaymentMethodData&gt; methodData;
+              PaymentItem total;
+              sequence&lt;PaymentDetailsModifier&gt; modifiers;
+              DOMString instrumentKey;
+            };
+          </pre>
+        </section>
         <section>
           <h2>
             <dfn>MethodData Population Algorithm</dfn>

--- a/index.html
+++ b/index.html
@@ -1304,11 +1304,21 @@
           The <a>PaymentRequestEvent</a> represents a received
           <a>PaymentRequest</a>.
         </p>
-        <pre class="idl">
+        <pre class="idl no-link-warnings">
+        dictionary PaymentRequestEventInit : ExtendableEventInit {
+          USVString topLevelOrigin;
+          USVString paymentRequestOrigin;
+          DOMString paymentRequestId;
+          sequence&lt;PaymentMethodData&gt; methodData;
+          PaymentItem total;
+          sequence&lt;PaymentDetailsModifier&gt; modifiers;
+          DOMString instrumentKey;
+        };
+
         [Constructor(DOMString type, PaymentRequestEventInit eventInitDict), Exposed=ServiceWorker]
         interface PaymentRequestEvent : ExtendableEvent {
-          readonly attribute DOMString topLevelOrigin;
-          readonly attribute DOMString paymentRequestOrigin;
+          readonly attribute USVString topLevelOrigin;
+          readonly attribute USVString paymentRequestOrigin;
           readonly attribute DOMString paymentRequestId;
           readonly attribute FrozenArray&lt;PaymentMethodData&gt; methodData;
           readonly attribute PaymentItem total;
@@ -1316,16 +1326,6 @@
           readonly attribute DOMString instrumentKey;
           Promise&lt;WindowClient&gt; openWindow(USVString url);
           void respondWith(Promise&lt;PaymentAppResponse&gt;appResponse);
-        };
-
-        dictionary PaymentRequestEventInit : ExtendableEventInit {
-          DOMString topLevelOrigin;
-          DOMString paymentRequestOrigin;
-          DOMString paymentRequestId;
-          sequence&lt;PaymentMethodData&gt; methodData;
-          PaymentItem total;
-          sequence&lt;PaymentDetailsModifier&gt; modifiers;
-          DOMString instrumentKey;
         };
       </pre>
         <section>

--- a/index.html
+++ b/index.html
@@ -1435,13 +1435,6 @@
           <h2>
             <dfn>PaymentRequestEventInit</dfn> dictionary
           </h2>
-          <p>
-            The <dfn>topLevelOrigin</dfn>, <dfn>paymentRequestOrigin</dfn>,
-            <dfn>paymentRequestId</dfn>, <dfn> methodData</dfn>,
-            <dfn>total</dfn>, <dfn> modifiers</dfn>, and
-            <dfn>instrumentKey</dfn> members share their definitions with
-            those defined for <a>PaymentRequestEvent</a>
-          </p>
           <pre class="idl">
             dictionary PaymentRequestEventInit : ExtendableEventInit {
               USVString topLevelOrigin;
@@ -1453,6 +1446,13 @@
               DOMString instrumentKey;
             };
           </pre>
+          <p>
+            The <dfn>topLevelOrigin</dfn>, <dfn>paymentRequestOrigin</dfn>,
+            <dfn>paymentRequestId</dfn>, <dfn>methodData</dfn>,
+            <dfn>total</dfn>, <dfn>modifiers</dfn>, and
+            <dfn>instrumentKey</dfn> members share their definitions with those
+            defined for <a>PaymentRequestEvent</a>
+          </p>
         </section>
         <section>
           <h2>


### PR DESCRIPTION
Need the constructor and init dictionary for compatibility with DOM events.

Here are some examples:
  https://www.w3.org/TR/push-api/#pushevent-interface
  https://wicg.github.io/BackgroundSync/spec/#sync-event
  https://notifications.spec.whatwg.org/#dom-notificationevent-notificationevent