### PR TITLE
Improve open window algorithm.

### DIFF
--- a/index.html
+++ b/index.html
@@ -267,6 +267,9 @@
           </p>
           <ul>
             <li>"<code><dfn data-cite=
+            "!WEBIDL-LS#invalidaccesserror">InvalidAccessError</dfn></code>"
+            </li>
+            <li>"<code><dfn data-cite=
             "!WEBIDL-LS#invalidstateerror">InvalidStateError</dfn></code>"
             </li>
             <li>"<code><dfn data-cite=
@@ -1751,6 +1754,11 @@
           <li>If <var>url</var>'s origin is not the same as the <a>service
           worker</a>'s origin associated with the payment handler, return a <a>
             Promise</a> rejected with a <a>SecurityError</a>.
+          </li>
+          <li>If this algorithm is not <a data-cite=
+          "!HTML#triggered-by-user-activation">triggered by user
+          activation</a>, return a <a>Promise</a> rejected with a
+          <a>InvalidAccessError</a>.
           </li>
           <li>Let <var>promise</var> be a new <a>Promise</a>.
           </li>

--- a/index.html
+++ b/index.html
@@ -1748,10 +1748,25 @@
           <li>If <var>url</var> is <code>about:blank</code>, return a
           <a>Promise</a> rejected with a <a>TypeError</a>.
           </li>
+          <li>If <var>url</var>'s origin is not the same as the <a>service
+          worker</a>'s origin associated with the payment handler, return a <a>
+            Promise</a> rejected with a <a>SecurityError</a>.
+          </li>
           <li>Let <var>promise</var> be a new <a>Promise</a>.
           </li>
           <li>Run these steps <a data-cite="!HTML#in-parallel">in parallel</a>:
             <ol>
+              <li>If <var>event</var>.<a>[[\windowClient]]</a> is not null,
+              then:
+                <ol>
+                  <li>If
+                    <var>event</var>.<a>[[\windowClient]]</a>.<a data-cite="!SERVICE-WORKERS#client-visibilitystate-attribute">visibilityState</a>
+                    is not "unloaded", reject <var>promise</var> with a
+                    <a>DOMException</a> whose name is
+                    "<a>InvalidStateError</a>" and abort these steps.
+                  </li>
+                </ol>
+              </li>
               <li>Let <var>newContext</var> be a new <a data-cite=
               "!HTML#top-level-browsing-context">top-level browsing
               context</a>.
@@ -1779,17 +1794,6 @@
               <a data-cite=
               "!SERVICE-WORKERS#create-windowclient-algorithm">create window
               client</a> algorithm with <var>newContext</var> as the argument.
-              </li>
-              <li>If <var>event</var>.<a>[[\windowClient]]</a> is not null,
-              then:
-                <ol>
-                  <li>If
-                    <var>event</var>.<a>[[\windowClient]]</a>.<a data-cite="!SERVICE-WORKERS#client-visibilitystate-attribute">visibilityState</a>
-                    is not "unloaded", reject <var>promise</var> with a
-                    <a>DOMException</a> whose name is
-                    "<a>InvalidStateError</a>" and abort these steps.
-                  </li>
-                </ol>
               </li>
               <li>Set <var>event</var>.<a>[[\windowClient]]</a> to
               <var>client</var>.


### PR DESCRIPTION
This change is fixing the following things:
  - Early reject SecurityError if the input url's origin is not the same as the
    service worker's origin associated with the payment handler.
  - Check whether already opened window exists before navigation.

This change is related to #163, #168, #169.