### PR TITLE
Add ImageObject dictionary.

### DIFF
--- a/index.html
+++ b/index.html
@@ -695,10 +695,52 @@
             When called, this method executes the following steps:
           </p>
           <ol>
+            <li>If the <a data-lt="PaymentInstrument.icons">icons</a> member of
+            <var>details</var> is present, then:
+              <ol>
+                <li>Let <var>convertedIcons</var> be the result of running the
+                <a>convert image objects</a> algorithm passing
+                <var>details</var>.<a data-lt=
+                "PaymentInstrument.icons">icons</a> as the argument.
+                </li>
+                <li>If the <var>convertedIcons</var> is an empty
+                <a>Sequence</a>, then return a <a>Promise</a> rejected with a
+                <a>TypeError</a>.
+                </li>
+                <li>Set <var>details</var>.<a data-lt=
+                "PaymentInstrument.icons">icons</a> to
+                <var>convertedIcons</var>.
+                </li>
+              </ol>
+            </li>
             <li>Let <var>p</var> be a new promise.
             </li>
             <li>Run the following steps in parallel:
               <ol>
+                <li>If the <a data-lt="PaymentInstrument.icons">icons</a>
+                member of <var>details</var> is present, then for each
+                <var>icon</var> in <var>details</var>.<a data-lt=
+                "PaymentInstrument.icons">icons</a>:
+                  <ol>
+                    <li>If the user agent wants to display the <var>icon</var>,
+                    then:
+                      <ol>
+                        <li>Let <var>fetchedImage</var> be the result of
+                        running the <a data-cite=
+                        "!appmanifest#fetching-image-objects">fetching image
+                        object</a> passing <var>icon</var> as the argument.
+                        </li>
+                        <li>Set <var>icon</var>.<a>[[\fetchedImage]]</a> to
+                        <var>fetchedImage</var>.
+                        </li>
+                      </ol>
+                    </li>
+                    <li>Otherwise, if no images are fetched, the user agent may
+                    set <var>icon</var>.<a>[[\fetchedImage]]</a> to fallback
+                    image.
+                    </li>
+                  </ol>
+                </li>
                 <li>If the collection contains a <a>PaymentInstrument</a> with
                 a matching <var>instrumentKey</var>, replace it with the
                 <a>PaymentInstrument</a> in <var>details</var>.
@@ -746,7 +788,7 @@
         <pre class="idl">
       dictionary PaymentInstrument {
         required DOMString name;
-        sequence&lt;ImageObjects&gt; icons;
+        sequence&lt;ImageObject&gt; icons;
         sequence&lt;DOMString&gt; enabledMethods;
         object capabilities;
       };
@@ -788,11 +830,6 @@
             <a>supportedTypes</a>.
           </dd>
         </dl>
-        <p class="issue" title="ImageObjects not Defined" data-number="125">
-          ImageObjects comes from the Web App Manifest specification. Should we
-          reference the definition normatively, or make use of a simpler
-          structure here?
-        </p>
       </section>
       <section data-dfn-for="PaymentWallets" data-link-for="PaymentWallets">
         <h2>
@@ -918,10 +955,50 @@
             When called, this method executes the following steps:
           </p>
           <ol>
+            <li>If the <a data-lt="PaymentWallet.icons">icons</a> member of
+            <var>details</var> is present, then:
+              <ol>
+                <li>Let <var>convertedIcons</var> be the result of running the
+                <a>convert image objects</a> algorithm passing
+                <var>details</var>.<a data-lt="PaymentWallet.icons">icons</a>
+                as the argument.
+                </li>
+                <li>If the <var>convertedIcons</var> is an empty
+                <a>Sequence</a>, then return a <a>Promise</a> rejected with a
+                <a>TypeError</a>.
+                </li>
+                <li>Set <var>details</var>.<a data-lt=
+                "PaymentWallet.icons">icons</a> to <var>convertedIcons</var>.
+                </li>
+              </ol>
+            </li>
             <li>Let <var>p</var> be a new promise.
             </li>
             <li>Run the following steps in parallel:
               <ol>
+                <li>If the <a data-lt="PaymentWallet.icons">icons</a> member of
+                <var>details</var> is present, then for each <var>icon</var> in
+                <var>details</var>.<a data-lt="PaymentWallet.icons">icons</a>:
+                  <ol>
+                    <li>If the user agent wants to display the <var>icon</var>,
+                    then:
+                      <ol>
+                        <li>Let <var>fetchedImage</var> be the result of
+                        running the <a data-cite=
+                        "!appmanifest#fetching-image-objects">fetching image
+                        object</a> passing <var>icon</var> as the argument.
+                        </li>
+                        <li>Set <var>icon</var>.<a>[[\fetchedImage]]</a> to
+                        <var>fetchedImage</var>.
+                        </li>
+                      </ol>
+                    </li>
+                    <li>Otherwise, if no images are fetched, the user agent may
+                    set <var>icon</var>.<a>[[\fetchedImage]]</a> to fallback
+                    image.
+                    </li>
+                  </ol>
+                </li>
                 <li>If the collection contains a <a>PaymentWallet</a> with a
                 matching <var>walletKey</var>, replace it with the
                 <a>PaymentWallet</a> in <var>details</var>.
@@ -1007,6 +1084,109 @@
             from appearing in more than one <a>Wallet</a>.
           </dd>
         </dl>
+      </section>
+      <section data-dfn-for="ImageObject" data-link-for="ImageObject">
+        <h2>
+          <dfn>ImageObject</dfn> dictionary
+        </h2>
+        <pre class="idl">
+      dictionary ImageObject {
+          required USVString src;
+          DOMString sizes;
+          DOMString type;
+      };
+      </pre>
+        <dl>
+          <dt>
+            <dfn>src</dfn> member
+          </dt>
+          <dd>
+            The <a>src</a> member is used to specify the <a>ImageObject</a>'s
+            source. It is a URL from which the user agent can fetch the image’s
+            data.
+          </dd>
+          <dt>
+            <dfn>sizes</dfn> member
+          </dt>
+          <dd>
+            The <a>sizes</a> member is used to specify the <a>ImageObject</a>'s
+            sizes. It follows the spec of sizes member in <a data-cite=
+            "!HTML#the-link-element">HTML link element</a>, which is a string
+            consisting of an <a data-cite=
+            "!HTML#unordered-set-of-unique-space-separated-tokens">unordered
+            set of unique space-separated tokens</a> which are <a data-cite=
+            "!HTML#ascii-case-insensitive">ASCII case-insensitive</a> that
+            represents the dimensions of an image. Each keyword is either an
+            <a data-cite="!HTML#ascii-case-insensitive">ASCII
+            case-insensitive</a> match for the string "any", or a value that
+            consists of two valid non-negative integers that do not have a
+            leading U+0030 DIGIT ZERO (0) character and that are separated by a
+            single U+0078 LATIN SMALL LETTER X or U+0058 LATIN CAPITAL LETTER X
+            character. The keywords represent icon sizes in raw pixels (as
+            opposed to CSS pixels). When multiple image objects are available,
+            a user agent MAY use the value to decide which icon is most
+            suitable for a display context (and ignore any that are
+            inappropriate). The parsing steps for the <a>sizes</a> member MUST
+            follow <a data-cite="!HTML#attr-link-sizes">the parsing steps for
+            HTML link element sizes attribute</a>.
+          </dd>
+          <dt>
+            <dfn>type</dfn> member
+          </dt>
+          <dd>
+            The <a>type</a> member is used to specify the <a>ImageObject</a>'s
+            MIME type. It is a hint as to the media type of the image. The
+            purpose of this member is to allow a user agent to ignore images of
+            media types it does not support.
+          </dd>
+        </dl>
+      </section>
+      <section>
+        <h2>
+          <dfn>Convert image objects</dfn>
+        </h2>
+        <p>
+          When this algorithm with <var>inputImages</var> parameter is invoked,
+          the user agent must runs the following steps:
+        </p>
+        <ol class="algorithm">
+          <li>Let <var>outputImages</var> be an empty <a>Sequence</a> of
+          <a>ImageObject</a>.
+          </li>
+          <li>For each <var>image</var> in <var>inputImages</var>:
+            <ol>
+              <li>If <var>image</var>.<a data-lt="ImageObject.type">type</a> is
+              not a <a data-cite="#valid-mime-type">valid MIME type</a> or the
+              value of type is not a supported media format, then return an
+              empty <a>Sequence</a> of <a>ImageObject</a>.
+              </li>
+              <li>If <var>image</var>.<a data-lt="ImageObject.sizes">sizes</a>
+              is not a <a data-lt="ImageObject.sizes">valid value</a>, then
+              return an empty <a>Sequence</a> of <a>ImageObject</a>.
+              </li>
+              <li>Let <var>url</var> be the result of parsing
+              <var>image</var>.<a data-lt="ImageObject.src">src</a> with the
+              <a data-cite="!HTML#context-object">context object</a>'s
+              <a data-cite="!HTML#relevant-settings-object">relevant settings
+              object</a>'s <a data-cite="!HTML#api-base-url">API base URL</a>.
+              </li>
+              <li>If <var>url</var> is failure, then return an empty
+              <a>Sequence</a> of <a>ImageObject</a>.
+              </li>
+              <li>If <var>url</var>'s <a data-cite="!HTML#concept-url-scheme">
+                scheme</a> is not one of "http" and "https", then return an
+                empty <a>Sequence</a> of <a>ImageObject</a>.
+              </li>
+              <li>Set <var>image</var>.<a data-lt="ImageObject.src">src</a> to
+              <var>url</var>.
+              </li>
+              <li>Append <var>image</var> to <var>outputImages</var>
+              </li>
+            </ol>
+          </li>
+          <li>Return <var>outputImages</var>.
+          </li>
+        </ol>
       </section>
       <section id="register-example" class="informative">
         <h2>
@@ -1599,6 +1779,19 @@
               The currently active <dfn>WindowClient</dfn>. This is set if a
               payment handler is currently showing a window to the user.
               Otherwise, it is null.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>[[\fetchedImage]]</dfn>
+            </td>
+            <td>
+              undefined
+            </td>
+            <td>
+              This value is a result of <a data-cite=
+              "!appmanifest#fetching-image-objects">fetching image object</a>
+              or a fallback image provided by the user agent.
             </td>
           </tr>
         </table>

--- a/index.html
+++ b/index.html
@@ -1187,6 +1187,62 @@
           <li>Return <var>outputImages</var>.
           </li>
         </ol>
+        <p>
+          According to the step 2.3, it is also possible to use the relative
+          url for <var>image</var>.<a data-lt="ImageObject.src">src</a>. The
+          following examples show how to resolve the relative url in each
+          execution context.
+        </p>
+        <pre class="example html" title=
+        "Resolving the relative URL of image.src in execution context of window object.">
+
+&lt;-- This example is located in https://www.example.com/bobpay/index.html --&gt;
+&lt;script&gt;
+
+const instrumentKey = "c8126178-3bba-4d09-8f00-0771bcfd3b11";
+const { registration } = await navigator.serviceWorker.register("/register/sw.js");
+await registration.paymentManager.paymentInstruments.set({
+  instrumentKey,
+  {
+    name: "My Bob Pay Account: john@example.com",
+    enabledMethods: ["https://bobpay.com/"],
+    icons: [{
+      src: "icon/lowres.webp",
+      sizes: "48x48",
+      type: "image/webp"
+    }]
+  });
+
+const { storedInstrument } =
+  await registration.paymentManager.paymentInstruments.get(instrumentKey);
+
+// storedInstrument.icons[0].src == "https://www.example.com/bobpay/icon/lowres.webp";
+
+&lt;/script&gt;
+      </pre>
+        <pre class="example js" title=
+        "Resolving the relative URL of image.src in execution context of service worker.">
+
+// This example is located in https://www.example.com/register/sw.js
+
+const instrumentKey = "c8126178-3bba-4d09-8f00-0771bcfd3b11";
+await self.registration.paymentManager.paymentInstruments.set({
+  instrumentKey,
+  {
+    name: "My Bob Pay Account: john@example.com",
+    enabledMethods: ["https://bobpay.com/"],
+    icons: [{
+      src: "../bobpay/icon/lowres.webp",
+      sizes: "48x48",
+      type: "image/webp"
+    }]
+  });
+
+const { storedInstrument } =
+  await registration.paymentManager.paymentInstruments.get(instrumentKey);
+
+// storedInstrument.icons[0].src == "https://www.example.com/bobpay/icon/lowres.webp";
+      </pre>
       </section>
       <section id="register-example" class="informative">
         <h2>

--- a/index.html
+++ b/index.html
@@ -1190,13 +1190,14 @@
         <p>
           According to the step 2.3, it is also possible to use the relative
           url for <var>image</var>.<a data-lt="ImageObject.src">src</a>. The
-          following examples show how to resolve the relative url in each
-          execution context.
+          following examples illustrate how relative URL resolution works in
+          different execution contexts.
         </p>
         <pre class="example html" title=
         "Resolving the relative URL of image.src in execution context of window object.">
 
-&lt;-- This example is located in https://www.example.com/bobpay/index.html --&gt;
+
+&lt;-- In this example, code is located in https://www.example.com/bobpay/index.html --&gt;
 &lt;script&gt;
 
 const instrumentKey = "c8126178-3bba-4d09-8f00-0771bcfd3b11";
@@ -1223,7 +1224,8 @@ const { storedInstrument } =
         <pre class="example js" title=
         "Resolving the relative URL of image.src in execution context of service worker.">
 
-// This example is located in https://www.example.com/register/sw.js
+
+// In this example, code is located in https://www.example.com/register/sw.js
 
 const instrumentKey = "c8126178-3bba-4d09-8f00-0771bcfd3b11";
 await self.registration.paymentManager.paymentInstruments.set({

--- a/index.html
+++ b/index.html
@@ -735,10 +735,6 @@
                         </li>
                       </ol>
                     </li>
-                    <li>Otherwise, if no images are fetched, the user agent may
-                    set <var>icon</var>.<a>[[\fetchedImage]]</a> to fallback
-                    image.
-                    </li>
                   </ol>
                 </li>
                 <li>If the collection contains a <a>PaymentInstrument</a> with
@@ -993,10 +989,6 @@
                         </li>
                       </ol>
                     </li>
-                    <li>Otherwise, if no images are fetched, the user agent may
-                    set <var>icon</var>.<a>[[\fetchedImage]]</a> to fallback
-                    image.
-                    </li>
                   </ol>
                 </li>
                 <li>If the collection contains a <a>PaymentWallet</a> with a
@@ -1147,7 +1139,7 @@
         </h2>
         <p>
           When this algorithm with <var>inputImages</var> parameter is invoked,
-          the user agent must runs the following steps:
+          the user agent must run the following steps:
         </p>
         <ol class="algorithm">
           <li>Let <var>outputImages</var> be an empty <a>Sequence</a> of
@@ -1174,8 +1166,8 @@
               <a>Sequence</a> of <a>ImageObject</a>.
               </li>
               <li>If <var>url</var>'s <a data-cite="!HTML#concept-url-scheme">
-                scheme</a> is not one of "http" and "https", then return an
-                empty <a>Sequence</a> of <a>ImageObject</a>.
+                scheme</a> is not "https", then return an empty <a>Sequence</a>
+                of <a>ImageObject</a>.
               </li>
               <li>Set <var>image</var>.<a data-lt="ImageObject.src">src</a> to
               <var>url</var>.
@@ -1195,6 +1187,7 @@
         </p>
         <pre class="example html" title=
         "Resolving the relative URL of image.src in execution context of window object.">
+
 
 
 &lt;-- In this example, code is located in https://www.example.com/bobpay/index.html --&gt;
@@ -1223,6 +1216,7 @@ const { storedInstrument } =
       </pre>
         <pre class="example js" title=
         "Resolving the relative URL of image.src in execution context of service worker.">
+
 
 
 // In this example, code is located in https://www.example.com/register/sw.js


### PR DESCRIPTION
The PaymentInstrument and the PaymentWallet have a sequence of ImageObject
as member, but there is no definition of ImageObject in the current spec.
We already know implicitly that is is similar to the image object in the
manifest spec[1]. But the does not have WebIDL definition of it, so it is
difficult to represent our data structure. To resolve the issue, this change
is adding ImageObject dictionary in WebIDL level.