### PR TITLE
Fix a example for PaymentManager.requestPermission().

### DIFF
--- a/index.html
+++ b/index.html
@@ -525,7 +525,7 @@
           <dfn>PaymentManager</dfn> interface
         </h2>
         <pre class="idl">
-      [SecureContext]
+      [SecureContext, Exposed=(Window,Worker)]
       interface PaymentManager {
         [SameObject] readonly attribute PaymentInstruments instruments;
         [Exposed=Window] static Promise&lt;PermissionState&gt; requestPermission();
@@ -1001,7 +1001,7 @@
             case "denied":
               return;
             case "prompt":
-              const result = await registration.paymentManager.requestPermission();
+              const result = await PaymentManager.requestPermission();
               if (result !== "granted") {
                 return;
               }


### PR DESCRIPTION
Although PaymentManager.requestPermission is defined as static method, its
example is using the service worker registration's paymentManager instance.
It's better to use the static method in the example if possible.

This PR is fixing #198 issue.