### PR TITLE
Resolve with null instead of reject with 'SecurityError' if PaymentRequestEvent.openWindow is opened in a different origin

### DIFF
--- a/index.html
+++ b/index.html
@@ -1707,7 +1707,7 @@
           </li>
           <li>If <var>url</var>'s origin is not the same as the <a>service
           worker</a>'s origin associated with the payment handler, return a <a>
-            Promise</a> rejected with a <a>SecurityError</a>.
+            Promise</a> resolved with null.
           </li>
           <li>If this algorithm is not <a data-cite=
           "!HTML#triggered-by-user-activation">triggered by user

--- a/index.html
+++ b/index.html
@@ -1262,7 +1262,7 @@
           readonly attribute object total;
           readonly attribute FrozenArray&lt;PaymentDetailsModifier&gt; modifiers;
           readonly attribute DOMString instrumentKey;
-          Promise&lt;WindowClient&gt; openWindow(USVString url);
+          Promise&lt;WindowClient?&gt; openWindow(USVString url);
           void respondWith(Promise&lt;PaymentHandlerResponse&gt;handlerResponse);
         };
       </pre>

--- a/index.html
+++ b/index.html
@@ -1705,10 +1705,6 @@
           <li>If <var>url</var> is <code>about:blank</code>, return a
           <a>Promise</a> rejected with a <a>TypeError</a>.
           </li>
-          <li>If <var>url</var>'s origin is not the same as the <a>service
-          worker</a>'s origin associated with the payment handler, return a <a>
-            Promise</a> rejected with a <a>SecurityError</a>.
-          </li>
           <li>If this algorithm is not <a data-cite=
           "!HTML#triggered-by-user-activation">triggered by user
           activation</a>, return a <a>Promise</a> rejected with a

--- a/index.html
+++ b/index.html
@@ -1743,8 +1743,7 @@
             service worker client</a> origin associated with the payment
             handler, then:
             <ol>
-              <li>Reject <var>promise</var> with a <a>DOMException</a> whose
-              name is "<a>SecurityError</a>".
+              <li>Resolve <var>promise</var> with null.
               </li>
               <li>Abort these steps.
               </li>


### PR DESCRIPTION
In the openWindow algorithm 14.1, the window is opened at that point, looks make no sense to reject with "SecurityError". 

This is also how Clients.openWindow works for service work.