### PR TITLE
Add userHint to PaymentManager

### DIFF
--- a/index.html
+++ b/index.html
@@ -591,8 +591,8 @@
             use this string to improve the user experience. For example, a user
             hint of "**** 1234" can remind the user that a particular card is
             available through this payment handler. When a agent displays all
-            payment instruments available through a payment handler, it may not
-            be useful to display the additional hint.
+            payment instruments available through a payment handler, it may 
+            cause confusion to display the additional hint.
           </p>
         </section>
       </section>

--- a/index.html
+++ b/index.html
@@ -590,7 +590,9 @@
             When displaying payment handler name and icon, the user agent may
             use this string to improve the user experience. For example, a user
             hint of "**** 1234" can remind the user that a particular card is
-            available through this payment handler.
+            available through this payment handler. When a agent displays all
+            payment instruments available through a payment handler, it may not
+            be useful to display the additional hint.
           </p>
         </section>
       </section>

--- a/index.html
+++ b/index.html
@@ -368,7 +368,7 @@
       interface PaymentManager {
         [SameObject] readonly attribute PaymentInstruments instruments;
         [Exposed=Window] static Promise&lt;PermissionState&gt; requestPermission();
-        DOMString userHint;     
+        attribute DOMString userHint;     
       };
       </pre>
         <p>

--- a/index.html
+++ b/index.html
@@ -529,6 +529,7 @@
       interface PaymentManager {
         [SameObject] readonly attribute PaymentInstruments instruments;
         [Exposed=Window] static Promise&lt;PermissionState&gt; requestPermission();
+        DOMString userHint;     
       };
       </pre>
         <p>
@@ -580,6 +581,17 @@
             <li>Resolve <var>p</var> with <var>permission</var>.
             </li>
           </ol>
+        </section>
+        <section>
+          <h2>
+            <dfn>userHint</dfn> attribute
+          </h2>
+          <p>
+            When displaying payment handler name and icon, the user agent may
+            use this string to improve the user experience. For example, a user
+            hint of "**** 1234" can remind the user that a particular card is
+            available through this payment handler.
+          </p>
         </section>
       </section>
       <section data-dfn-for="PaymentInstruments" data-link-for=


### PR DESCRIPTION
Based on a discussion with @adamroach and @rsolomakhin, I have written this pull request
to address issue #173 .

The idea is that the payment handler provides a user hint (e.g., "**** 1234") that can complement
name and icon information associated with the payment handler. Although the user agent
could compute hint information like this (e.g., based on N payment instruments managed by the payment handler), this attribute gives more control to the payment handler.

I did not attempt to specify exactly how the string should be used, or combined with the name/logo of the payment handler.

This user hint string does not affect user interface behavior. Specifically, it does not mean that a particular payment instrument will be invoked automatically when the user selects the payment handler.

Ian

