### PR TITLE
fix: PaymentInstruments.get not exceptional

### DIFF
--- a/index.html
+++ b/index.html
@@ -445,7 +445,7 @@
       [SecureContext, Exposed=(Window,Worker)]
       interface PaymentInstruments {
           Promise&lt;boolean&gt;           delete(DOMString instrumentKey);
-          Promise&lt;PaymentInstrument&gt; get(DOMString instrumentKey);
+          Promise&lt;any&gt; get(DOMString instrumentKey);
           Promise&lt;sequence&lt;DOMString&gt;&gt;  keys();
           Promise&lt;boolean&gt;           has(DOMString instrumentKey);
           Promise&lt;void&gt;              set(DOMString instrumentKey, PaymentInstrument details);
@@ -497,8 +497,7 @@
             matching <var>instrumentKey</var>, resolve <var>p</var> with that
             <a>PaymentInstrument</a>.
             </li>
-            <li>Otherwise, reject <var>p</var> with a <a>DOMException</a> whose
-            value is "<a>NotFoundError</a>".
+            <li>Otherwise, resolve <var>p</var> with <code>undefined</code>.
             </li>
           </ol>
         </section>


### PR DESCRIPTION
* closes #230


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-handler/pull/231.html" title="Last updated on Nov 28, 2017, 2:31 AM GMT">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-handler/55c501f...7eb932e.html" title="Last updated on Nov 28, 2017, 2:31 AM GMT">Diff</a>