### PR TITLE
Cross-origin iframes and feature policy.

### DIFF
--- a/index.html
+++ b/index.html
@@ -454,6 +454,7 @@
             <li>If the <a>document</a> is not <a>allowed to use</a> the
             policy-controlled-feature <code>payment</code>, reject <var>p</var>
             with <a>SecurityError</a>.
+            </li>
             <li>If the collection contains a <a>PaymentInstrument</a> with a
             matching <var>instrumentKey</var>, resolve <var>p</var> with that
             <a>PaymentInstrument</a>.
@@ -478,6 +479,7 @@
             <li>If the <a>document</a> is not <a>allowed to use</a> the
             policy-controlled-feature <code>payment</code>, reject <var>p</var>
             with <a>SecurityError</a>.
+            </li>
             <li>Resolve <var>p</var> with a <dfn>Sequence</dfn> that contains
             all the <var>instrumentKey</var>s for the <a>PaymentInstrument</a>s
             contained in the collection, in original insertion order.
@@ -500,6 +502,7 @@
             <li>If the <a>document</a> is not <a>allowed to use</a> the
             policy-controlled-feature <code>payment</code>, reject <var>p</var>
             with <a>SecurityError</a>.
+            </li>
             <li>If the collection contains a <a>PaymentInstrument</a> with a
             matching <var>instrumentKey</var>, resolve <var>p</var> with
             <b>true</b>.
@@ -551,6 +554,7 @@
             <li>If the <a>document</a> is not <a>allowed to use</a> the
             policy-controlled-feature <code>payment</code>, reject <var>p</var>
             with <a>SecurityError</a>.
+            </li>
             <li>If the <a data-lt="PaymentInstrument.icons">icons</a> member of
             <var>details</var> is present, then for each <var>icon</var> in
             <var>details</var>.<a data-lt="PaymentInstrument.icons">icons</a>:
@@ -598,6 +602,7 @@
             <li>If the <a>document</a> is not <a>allowed to use</a> the
             policy-controlled-feature <code>payment</code>, reject <var>p</var>
             with <a>SecurityError</a>.
+            </li>
             <li>Remove all <a>PaymentInstrument</a>s from the collection and
             resolve <var>p</var>.
             </li>

--- a/index.html
+++ b/index.html
@@ -426,6 +426,10 @@
             <li>Return <var>p</var> and perform the remaining steps in
             parallel:
             </li>
+            <li>If the <a>document</a> is not <a>allowed to use</a> the
+            policy-controlled-feature <code>payment</code>, reject <var>p</var>
+            with <a>SecurityError</a>.
+            </li>
             <li>If the collection contains a <a>PaymentInstrument</a> with a
             matching <var>instrumentKey</var>, remove it from the collection
             and resolve <var>p</var> with <b>true</b>.
@@ -447,6 +451,9 @@
             <li>Return <var>p</var> and perform the remaining steps in
             parallel:
             </li>
+            <li>If the <a>document</a> is not <a>allowed to use</a> the
+            policy-controlled-feature <code>payment</code>, reject <var>p</var>
+            with <a>SecurityError</a>.
             <li>If the collection contains a <a>PaymentInstrument</a> with a
             matching <var>instrumentKey</var>, resolve <var>p</var> with that
             <a>PaymentInstrument</a>.
@@ -468,6 +475,9 @@
             <li>Return <var>p</var> and perform the remaining steps in
             parallel:
             </li>
+            <li>If the <a>document</a> is not <a>allowed to use</a> the
+            policy-controlled-feature <code>payment</code>, reject <var>p</var>
+            with <a>SecurityError</a>.
             <li>Resolve <var>p</var> with a <dfn>Sequence</dfn> that contains
             all the <var>instrumentKey</var>s for the <a>PaymentInstrument</a>s
             contained in the collection, in original insertion order.
@@ -487,6 +497,9 @@
             <li>Return <var>p</var> and perform the remaining steps in
             parallel:
             </li>
+            <li>If the <a>document</a> is not <a>allowed to use</a> the
+            policy-controlled-feature <code>payment</code>, reject <var>p</var>
+            with <a>SecurityError</a>.
             <li>If the collection contains a <a>PaymentInstrument</a> with a
             matching <var>instrumentKey</var>, resolve <var>p</var> with
             <b>true</b>.
@@ -535,6 +548,9 @@
             <li>Return <var>p</var> and perform the remaining steps in
             parallel:
             </li>
+            <li>If the <a>document</a> is not <a>allowed to use</a> the
+            policy-controlled-feature <code>payment</code>, reject <var>p</var>
+            with <a>SecurityError</a>.
             <li>If the <a data-lt="PaymentInstrument.icons">icons</a> member of
             <var>details</var> is present, then for each <var>icon</var> in
             <var>details</var>.<a data-lt="PaymentInstrument.icons">icons</a>:
@@ -579,6 +595,9 @@
             <li>Return <var>p</var> and perform the remaining steps in
             parallel:
             </li>
+            <li>If the <a>document</a> is not <a>allowed to use</a> the
+            policy-controlled-feature <code>payment</code>, reject <var>p</var>
+            with <a>SecurityError</a>.
             <li>Remove all <a>PaymentInstrument</a>s from the collection and
             resolve <var>p</var>.
             </li>
@@ -2078,6 +2097,17 @@ window.addEventListener("message", function(e) {
           </li>
         </ul>
       </section>
+      <section>
+        <h2>
+          Iframes
+        </h2>
+        <ul>
+          <li>Cross-origin iframes should not be able to register payment
+          handlers, unless allowed by [[!feature-policy]], e.g., by specifying
+          the <code>allow="payment"</code> attribute on the iframe element.
+          </li>
+        </ul>
+      </section>
     </section>
     <section id="display" class="informative">
       <h2>
@@ -2177,7 +2207,8 @@ window.addEventListener("message", function(e) {
           HTML
         </dt>
         <dd>
-          The terms <dfn data-cite="!HTML#global-object">global object</dfn>,
+          The terms <dfn data-cite="!HTML#document">document</dfn>,
+          <dfn data-cite="!HTML#global-object">global object</dfn>,
           <dfn data-cite="!HTML#top-level-browsing-context">top-level browsing
           context</dfn>, <dfn data-cite="!HTML#structured-clone">structured
           clone</dfn>, <dfn data-cite="!HTML#event-handlers">event
@@ -2283,6 +2314,15 @@ window.addEventListener("message", function(e) {
           "!SERVICE-WORKERS#try-activate-algorithm">Try Activate</dfn>, and
           <dfn data-cite="!SERVICE-WORKERS#dfn-scope-url">scope URL</dfn> are
           defined in [[!SERVICE-WORKERS]].
+        </dd>
+      </dl>
+      <dl>
+        <dt>
+          Feature Policy
+        </dt>
+        <dd>
+          The term <dfn data-cite="!feature-policy#allowed-to-use">allowed to
+          use</dfn> is defined in [[!feature-policy]].
         </dd>
       </dl>
     </section>

--- a/index.html
+++ b/index.html
@@ -422,9 +422,9 @@
             <li>Return <var>p</var> and perform the remaining steps in
             parallel:
             </li>
-            <li>If the <a>document</a> is not <a>allowed to use</a> the
-            policy-controlled-feature <code>payment</code>, reject <var>p</var>
-            with <a>SecurityError</a>.
+            <li>If the <a>document</a> is not <a>allowed to use</a>
+            <code>payment</code>, reject <var>p</var> with
+            "<a>SecurityError</a>" <a>DOMException</a>.
             </li>
             <li>If the collection contains a <a>PaymentInstrument</a> with a
             matching <var>instrumentKey</var>, resolve <var>p</var> with that
@@ -447,9 +447,9 @@
             <li>Return <var>p</var> and perform the remaining steps in
             parallel:
             </li>
-            <li>If the <a>document</a> is not <a>allowed to use</a> the
-            policy-controlled-feature <code>payment</code>, reject <var>p</var>
-            with <a>SecurityError</a>.
+            <li>If the <a>document</a> is not <a>allowed to use</a>
+            <code>payment</code>, reject <var>p</var> with
+            "<a>SecurityError</a>" <a>DOMException</a>.
             </li>
             <li>Resolve <var>p</var> with a <dfn>Sequence</dfn> that contains
             all the <var>instrumentKey</var>s for the <a>PaymentInstrument</a>s
@@ -470,9 +470,9 @@
             <li>Return <var>p</var> and perform the remaining steps in
             parallel:
             </li>
-            <li>If the <a>document</a> is not <a>allowed to use</a> the
-            policy-controlled-feature <code>payment</code>, reject <var>p</var>
-            with <a>SecurityError</a>.
+            <li>If the <a>document</a> is not <a>allowed to use</a>
+            <code>payment</code>, reject <var>p</var> with
+            "<a>SecurityError</a>" <a>DOMException</a>.
             </li>
             <li>If the collection contains a <a>PaymentInstrument</a> with a
             matching <var>instrumentKey</var>, resolve <var>p</var> with
@@ -517,9 +517,9 @@
             <li>Return <var>p</var> and perform the remaining steps in
             parallel:
             </li>
-            <li>If the <a>document</a> is not <a>allowed to use</a> the
-            policy-controlled-feature <code>payment</code>, reject <var>p</var>
-            with <a>SecurityError</a>.
+            <li>If the <a>document</a> is not <a>allowed to use</a>
+            <code>payment</code>, reject <var>p</var> with
+            "<a>SecurityError</a>" <a>DOMException</a>.
             </li>
             <li>If the <a data-lt="PaymentInstrument.icons">icons</a> member of
             <var>details</var> is present, then for each <var>icon</var> in
@@ -565,9 +565,9 @@
             <li>Return <var>p</var> and perform the remaining steps in
             parallel:
             </li>
-            <li>If the <a>document</a> is not <a>allowed to use</a> the
-            policy-controlled-feature <code>payment</code>, reject <var>p</var>
-            with <a>SecurityError</a>.
+            <li>If the <a>document</a> is not <a>allowed to use</a>
+            <code>payment</code>, reject <var>p</var> with
+            "<a>SecurityError</a>" <a>DOMException</a>.
             </li>
             <li>Remove all <a>PaymentInstrument</a>s from the collection and
             resolve <var>p</var>.

--- a/index.html
+++ b/index.html
@@ -426,9 +426,9 @@
             <li>Return <var>p</var> and perform the remaining steps in
             parallel:
             </li>
-            <li>If the <a>document</a> is not <a>allowed to use</a> the
-            policy-controlled-feature <code>payment</code>, reject <var>p</var>
-            with <a>SecurityError</a>.
+            <li>If the <a>document</a> is not <a>allowed to use</a>
+            <code>payment</code>, reject <var>p</var> with
+            "<a>SecurityError</a>" <a>DOMException</a>.
             </li>
             <li>If the collection contains a <a>PaymentInstrument</a> with a
             matching <var>instrumentKey</var>, remove it from the collection
@@ -2107,9 +2107,10 @@ window.addEventListener("message", function(e) {
           Iframes
         </h2>
         <ul>
-          <li>Cross-origin iframes should not be able to register payment
-          handlers, unless allowed by [[!feature-policy]], e.g., by specifying
-          the <code>allow="payment"</code> attribute on the iframe element.
+          <li>The top-level document needs to explicitly grant access to nested
+          browsing contexts via the "payment" [[!feature-policy]], e.g., by
+          specifying the <code>allow="payment"</code> attribute on a
+          cross-origin iframe element.
           </li>
         </ul>
       </section>


### PR DESCRIPTION
Prohibit cross-origin iframes from installing payment handlers, unless
allowed by the feature policy.

closes #281

The following tasks have been completed:

 * [ ] web platform tests
 * [ ] MDN Docs added

Implementation commitment:

 * [ ] Safari
 * [x] [Chrome](https://crbug.com/828948)
 * [ ] Firefox
 * [ ] Edge


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rsolomakhin/payment-handler/pull/282.html" title="Last updated on Sep 19, 2018, 6:53 PM GMT (eb1fb88)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-handler/282/697480d...rsolomakhin:eb1fb88.html" title="Last updated on Sep 19, 2018, 6:53 PM GMT (eb1fb88)">Diff</a>