### PR TITLE
Throws NotAllowedError instead of InvalidAccessError

### DIFF
--- a/index.html
+++ b/index.html
@@ -1632,7 +1632,7 @@
           <li>If this algorithm is not <a data-cite=
           "!HTML#triggered-by-user-activation">triggered by user
           activation</a>, return a <a>Promise</a> rejected with a
-          <a>InvalidAccessError</a>.
+          "<a>NotAllowedError</a>" <a>DOMException</a>.
           </li>
           <li>Let <var>promise</var> be a new <a>Promise</a>.
           </li>
@@ -2237,22 +2237,13 @@ window.addEventListener("message", function(e) {
           </p>
           <ul>
             <li>"<code><dfn data-cite=
-            "!WEBIDL#invalidaccesserror">InvalidAccessError</dfn></code>"
-            </li>
-            <li>"<code><dfn data-cite=
             "!WEBIDL#invalidstateerror">InvalidStateError</dfn></code>"
             </li>
             <li>"<code><dfn data-cite=
             "!WEBIDL#notallowederror">NotAllowedError</dfn></code>"
             </li>
             <li>"<code><dfn data-cite=
-            "!WEBIDL#notfounderror">NotFoundError</dfn></code>"
-            </li>
-            <li>"<code><dfn data-cite=
             "!WEBIDL#operationerror">OperationError</dfn></code>"
-            </li>
-            <li>"<code><dfn data-cite=
-            "!WEBIDL#securityerror">SecurityError</dfn></code>"
             </li>
           </ul>
         </dd>


### PR DESCRIPTION
The InvalidAccessError was already deprecated.

Implementation commitment:

 * [x] Chrome (http://crrev.com/c/1013659)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/romandev/payment-handler/pull/291.html" title="Last updated on Apr 16, 2018, 4:03 PM GMT (d362fb0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-handler/291/d9ebc35...romandev:d362fb0.html" title="Last updated on Apr 16, 2018, 4:03 PM GMT (d362fb0)">Diff</a>