### PR TITLE
Remove link to issue 157

### DIFF
--- a/index.html
+++ b/index.html
@@ -1052,13 +1052,6 @@
           handler and return the result.
           </li>
         </ol>
-        <div class="issue" data-number="157">
-          This is the current thinking about filtering of payment instruments.
-          As we continue to experiment with implementations, we are soliciting
-          feedback on this approach. Also see the <a href=
-          "https://github.com/w3c/payment-request-info/wiki/PaymentMethodPractice#canmakepaymentevent-implementation">
-          Wiki page</a>.
-        </div>
         <section id="capabilities-example" class="informative">
           <h2>
             How to specify capabilities


### PR DESCRIPTION
The issue 157 was already closed and it is making a respec error.

closes #157


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/romandev/payment-handler/pull/292.html" title="Last updated on Apr 15, 2018, 6:39 AM GMT (2a0bbc2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-handler/292/d9ebc35...romandev:2a0bbc2.html" title="Last updated on Apr 15, 2018, 6:39 AM GMT (2a0bbc2)">Diff</a>