### PR TITLE
Add [SameObject] to paymentManager attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -306,7 +306,7 @@
         </p>
         <pre class="idl">
         partial interface ServiceWorkerRegistration {
-          readonly attribute PaymentManager paymentManager;
+          [SameObject] readonly attribute PaymentManager paymentManager;
         };
         </pre>
         <p>


### PR DESCRIPTION
We don't need to create a new object when accessing paymentManager
attribute. So, we just add `[SameObject]`.

Implementation commitment:

 * [x] Chrome (http://crrev.com/c/1013660)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/romandev/payment-handler/pull/293.html" title="Last updated on Apr 16, 2018, 3:39 PM GMT (fd8a710)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-handler/293/d9ebc35...romandev:fd8a710.html" title="Last updated on Apr 16, 2018, 3:39 PM GMT (fd8a710)">Diff</a>