### PR TITLE
Removed note on payment method manifest and added reference to it

### DIFF
--- a/index.html
+++ b/index.html
@@ -980,8 +980,7 @@
               has no default action.
               </li>
               <li>Set the <a data-lt=
-              "PaymentRequestEvent.topOrigin">topOrigin</a>,
-              <a data-lt=
+              "PaymentRequestEvent.topOrigin">topOrigin</a>, <a data-lt=
               "PaymentRequestEvent.paymentRequestOrigin">paymentRequestOrigin</a>,
               <a data-lt="PaymentRequestEvent.methodData">methodData</a>, and
               <a data-lt="PaymentRequestEvent.modifiers">modifiers</a>
@@ -1188,12 +1187,12 @@
             Returns a string that indicates the <a data-cite=
             "!HTML#origin">origin</a> where a <a>PaymentRequest</a> was
             initialized. When a <a>PaymentRequest</a> is initialized in the
-            <a>topOrigin</a>, the attributes have the same value,
-            otherwise the attributes have different values. For example, when a
+            <a>topOrigin</a>, the attributes have the same value, otherwise the
+            attributes have different values. For example, when a
             <a>PaymentRequest</a> is initialized within an iframe from an
-            origin other than <a>topOrigin</a>, the value of this
-            attribute is the origin of the iframe. This attribute is
-            initialized by <a>Handling a PaymentRequestEvent</a>.
+            origin other than <a>topOrigin</a>, the value of this attribute is
+            the origin of the iframe. This attribute is initialized by
+            <a>Handling a PaymentRequestEvent</a>.
           </p>
         </section>
         <section>
@@ -1513,10 +1512,10 @@
               and has no default action.
               </li>
               <li>Set the <a data-lt=
-              "PaymentRequestEvent.topOrigin">topOrigin</a> attribute
-              of <var>e</var> to <a data-cite=
-              "!HTML#ascii-serialisation-of-an-origin">the serialization of the
-              origin</a> of the top level payee web page.
+              "PaymentRequestEvent.topOrigin">topOrigin</a> attribute of <var>
+                e</var> to <a data-cite=
+                "!HTML#ascii-serialisation-of-an-origin">the serialization of
+                the origin</a> of the top level payee web page.
               </li>
               <li>Set the <a data-lt=
               "PaymentRequestEvent.paymentRequestOrigin">paymentRequestOrigin</a>
@@ -2026,9 +2025,13 @@ window.addEventListener("message", function(e) {
       </section>
       <section>
         <h2>
-          Payment App Authenticity
+          Authorized Payment Apps
         </h2>
         <ul>
+          <li>The party responsible for a payment method authorizes payment
+          apps through a [[payment-method-manifest]]. See the <a>Handling a
+          CanMakePaymentEvent</a> algorithm for details.
+          </li>
           <li>The user agent is not required to make available payment handlers
           that pose security issues. When a payment handler is unavailable for
           security reasons, the user agent should provide rationale to the
@@ -2036,12 +2039,6 @@ window.addEventListener("message", function(e) {
           also inform the user to help avoid confusion.
           </li>
         </ul>
-        <p class="note">
-          The Web Payments Working Group is also discussing Payment App
-          authenticity; see the (draft) <a href=
-          "https://w3c.github.io/payment-method-manifest/">Payment Method
-          Manifest</a>.
-        </p>
       </section>
       <section>
         <h2>


### PR DESCRIPTION
Since that spec has now been published. Refer to canMakePaymetn() algorithm
for more info on authorized payment apps

Relates to #308 but does not close it. 

The following tasks have been completed:

 * [ ] web platform tests (link)
 * [ ] MDN Docs added (link)

Implementation commitment:

 * [ ] Safari (link to issue)
 * [ ] Chrome (link to issue)
 * [ ] Firefox (link to issue)
 * [ ] Edge (public signal)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-handler/pull/311.html" title="Last updated on Aug 2, 2018, 7:31 PM GMT (2095ac5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-handler/311/16e9e5b...2095ac5.html" title="Last updated on Aug 2, 2018, 7:31 PM GMT (2095ac5)">Diff</a>