### PR TITLE
Remove modifiers from CanMakePaymentEvent.

### DIFF
--- a/index.html
+++ b/index.html
@@ -912,7 +912,6 @@
           readonly attribute USVString topOrigin;
           readonly attribute USVString paymentRequestOrigin;
           readonly attribute FrozenArray&lt;PaymentMethodData&gt; methodData;
-          readonly attribute FrozenArray&lt;PaymentDetailsModifier&gt; modifiers;
           void respondWith(Promise&lt;boolean&gt;canMakePaymentResponse);
         };
         </pre>
@@ -939,13 +938,12 @@
               USVString topOrigin;
               USVString paymentRequestOrigin;
               sequence&lt;PaymentMethodData&gt; methodData;
-              sequence&lt;PaymentDetailsModifier&gt; modifiers;
             };
           </pre>
           <p>
-            The <dfn>topOrigin</dfn>, <dfn>paymentRequestOrigin</dfn>,
-            <dfn>methodData</dfn>, and <dfn>modifiers</dfn> members share their
-            definitions with those defined for <a>PaymentRequestEvent</a>.
+            The <dfn>topOrigin</dfn>, <dfn>paymentRequestOrigin</dfn>, and
+            <dfn>methodData</dfn> members share their definitions with those
+            defined for <a>PaymentRequestEvent</a>.
           </p>
         </section>
       </section>
@@ -982,8 +980,7 @@
               <li>Set the <a data-lt=
               "PaymentRequestEvent.topOrigin">topOrigin</a>, <a data-lt=
               "PaymentRequestEvent.paymentRequestOrigin">paymentRequestOrigin</a>,
-              <a data-lt="PaymentRequestEvent.methodData">methodData</a>, and
-              <a data-lt="PaymentRequestEvent.modifiers">modifiers</a>
+              and <a data-lt="PaymentRequestEvent.methodData">methodData</a>
               attributes of <var>e</var> the same way as when handling
               <a>PaymentRequestEvent</a>.
               </li>


### PR DESCRIPTION
closes https://github.com/w3c/payment-handler/issues/289

The following tasks have been completed:

 * [ ] web platform tests (link)
 * [ ] MDN Docs added (link)

Implementation commitment:

 * [ ] Safari (link to issue)
 * [ ] Chrome (link to issue)
 * [ ] Firefox (link to issue)
 * [ ] Edge (public signal)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rsolomakhin/payment-handler/pull/315.html" title="Last updated on Aug 27, 2018, 1:22 PM GMT (18634c7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-handler/315/4a9fd10...rsolomakhin:18634c7.html" title="Last updated on Aug 27, 2018, 1:22 PM GMT (18634c7)">Diff</a>