### PR TITLE
chore: move former editors to the right place

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,19 +21,6 @@
                     companyURL: "https://ripple.com",
                     w3cid:      42590
                 },
-                {   name:       "Tommy Thorsen",
-                    url:        "https://github.com/tommythorsen",
-                    company:    "Opera",
-                    companyURL: "https://opera.com",
-                    w3cid:      90636,
-                    note: "Former Editor"
-                },
-                {   name:       "Adam Roach",
-                    url:        "https://github.com/adamroach",
-                    company:    "Mozilla",
-                    companyURL: "https://mozilla.org",
-                    w3cid:      67785
-                },
                 {   name:       "Andre Lyver",
                     url:        "https://github.com/lyverovski",
                     company:    "Shopify",
@@ -56,6 +43,20 @@
                     company:    "Samsung",
                     companyURL: "https://www.samsung.com/",
                     w3cid:      77147
+                },
+            ],
+            formerEditors: [
+                {   name:       "Tommy Thorsen",
+                    url:        "https://github.com/tommythorsen",
+                    company:    "Opera",
+                    companyURL: "https://opera.com",
+                    w3cid:      90636,
+                },
+                {   name:       "Adam Roach",
+                    url:        "https://github.com/adamroach",
+                    company:    "Mozilla",
+                    companyURL: "https://mozilla.org",
+                    w3cid:      67785
                 },
             ],
             license:      "w3c-software-doc",


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-handler/pull/328.html" title="Last updated on Dec 12, 2018, 5:11 AM GMT (7424484)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-handler/328/be353e8...7424484.html" title="Last updated on Dec 12, 2018, 5:11 AM GMT (7424484)">Diff</a>