### PR TITLE
Add missing space after Promise<T> types

### DIFF
--- a/index.html
+++ b/index.html
@@ -884,7 +884,7 @@
           readonly attribute USVString topOrigin;
           readonly attribute USVString paymentRequestOrigin;
           readonly attribute FrozenArray&lt;PaymentMethodData&gt; methodData;
-          void respondWith(Promise&lt;boolean&gt;canMakePaymentResponse);
+          void respondWith(Promise&lt;boolean&gt; canMakePaymentResponse);
         };
         </pre>
         <p>
@@ -1219,7 +1219,7 @@
           readonly attribute boolean requestBillingAddress;
           Promise&lt;WindowClient?&gt; openWindow(USVString url);
           Promise&lt;PaymentMethodChangeResponse?&gt; changePaymentMethod(DOMString methodName, optional object? methodDetails = null);
-          void respondWith(Promise&lt;PaymentHandlerResponse&gt;handlerResponsePromise);
+          void respondWith(Promise&lt;PaymentHandlerResponse&gt; handlerResponsePromise);
         };
         </pre>
         <section>


### PR DESCRIPTION
Spotted in https://github.com/web-platform-tests/wpt/pull/19241.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/foolip/payment-handler/pull/345.html" title="Last updated on Sep 24, 2019, 8:19 AM UTC (3844116)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-handler/345/4ca3f10...foolip:3844116.html" title="Last updated on Sep 24, 2019, 8:19 AM UTC (3844116)">Diff</a>