### PR TITLE
Fix shippingOptions and PaymentOption links to point to Payment Request API

### DIFF
--- a/index.html
+++ b/index.html
@@ -1358,7 +1358,8 @@
             <dfn>requestBillingAddress</dfn> attribute
           </h2>
           <p>
-            The value of <a>PaymentOptions</a>.<var>requestBillingAddress</var>
+            The value of <a data-cite=
+            "payment-request/#dom-paymentoptions">PaymentOptions</a>.<var>requestBillingAddress</var>
             in the <a>PaymentRequest</a>.
           </p>
         </section>
@@ -1367,9 +1368,10 @@
             <dfn>paymentOptions</dfn> attribute
           </h2>
           <p>
-            The value of <a>PaymentOptions</a> in the <a>PaymentRequest</a>.
-            Available only when shippingAddress and/or any subset of payer's
-            contact information are requested.
+            The value of <a data-cite=
+            "payment-request/#dom-paymentoptions">PaymentOptions</a> in the
+            <a>PaymentRequest</a>. Available only when shippingAddress and/or
+            any subset of payer's contact information are requested.
           </p>
         </section>
         <section>
@@ -1377,10 +1379,12 @@
             <dfn>shippingOptions</dfn> attribute
           </h2>
           <p>
-            The value of <a>ShippingOptions</a> on the
-            <a>PaymentDetailsInit</a> from the corresponding
-            <a>PaymentRequest</a>. Available only when shipping address is
-            requested.
+            The value of <a data-cite=
+            "payment-request#dom-paymentdetailsbase-shippingoptions">ShippingOptions</a>
+            in the <a>PaymentDetailsInit</a> dictionary of the corresponding
+            <a>PaymentRequest</a>.(<a>PaymentDetailsInit</a> inherits
+            ShippingOptions from <a>PaymentDetailsBase</a>). Available only
+            when shipping address is requested.
           </p>
         </section>
         <section>
@@ -2237,9 +2241,9 @@ document.getElementById("form").addEventListener("submit", e =&gt; {
               <var>payerNameRequired</var>, <var>payerEmailRequired</var>, and
               <var>payerPhoneRequired</var> are true, respectively.):
                 <ol>
-                  For each <var>member</var>in <var>handlerResponse</var>Let
-                  <var>serializeMember</var>be the result of <a data-cite=
-                  "HTML#structuredserialize">StructuredSerialize</a>with
+                  For each <var>member</var> in <var>handlerResponse</var> Let
+                  <var>serializeMember</var> be the result of <a data-cite=
+                  "HTML#structuredserialize">StructuredSerialize</a> with
                   <var>handlerResponse</var>.<var>member</var>. Rethrow any
                   exceptions.
                 </ol>
@@ -2250,9 +2254,9 @@ document.getElementById("form").addEventListener("submit", e =&gt; {
                 <ol>
                   <li>Deserialize serialized members:
                     <ol>
-                      For each <var>serializeMember</var>let
-                      <var>member</var>be the result of <a data-cite=
-                      "HTML#structureddeserialize">StructuredDeserialize</a>with
+                      For each <var>serializeMember</var> let
+                      <var>member</var> be the result of <a data-cite=
+                      "HTML#structureddeserialize">StructuredDeserialize</a> with
                       <var>serializeMember</var>. Rethrow any exceptions.
                     </ol>
                   </li>
@@ -2580,6 +2584,8 @@ document.getElementById("form").addEventListener("submit", e =&gt; {
           "payment-request#paymentdetailsmodifier-dictionary">paymentDetailsModifier</dfn>,
           <dfn data-cite=
           "payment-request#paymentdetailsinit-dictionary">paymentDetailsInit</dfn>,
+          <dfn data-cite=
+          "payment-request#paymentdetailsbase-dictionary">paymentDetailsBase</dfn>,
           <dfn data-cite=
           "payment-request#paymentmethoddata-dictionary">PaymentMethodData</dfn>,
           <dfn data-cite=


### PR DESCRIPTION
closes #355

I also manually fixed the spacing inside ```<ol></ol>``` tags where tidy (5.6.0) had deleted spaces after closing tags:
e.g tidy converts ```For each <var>member</var> in...``` to ```For each <var>member</var>in...``` deleting the space between ```</var>``` and ```in```.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sahel-sh/payment-handler/pull/356.html" title="Last updated on Nov 29, 2019, 3:59 AM UTC (e4b1721)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-handler/356/a2f1ede...sahel-sh:e4b1721.html" title="Last updated on Nov 29, 2019, 3:59 AM UTC (e4b1721)">Diff</a>