### PR TITLE
Security consideration: user consent before payment

### DIFF
--- a/index.html
+++ b/index.html
@@ -2241,9 +2241,9 @@ document.getElementById("form").addEventListener("submit", e =&gt; {
               <var>payerNameRequired</var>, <var>payerEmailRequired</var>, and
               <var>payerPhoneRequired</var> are true, respectively.):
                 <ol>
-                  For each <var>member</var> in <var>handlerResponse</var> Let
-                  <var>serializeMember</var> be the result of <a data-cite=
-                  "HTML#structuredserialize">StructuredSerialize</a> with
+                  For each <var>member</var>in <var>handlerResponse</var>Let
+                  <var>serializeMember</var>be the result of <a data-cite=
+                  "HTML#structuredserialize">StructuredSerialize</a>with
                   <var>handlerResponse</var>.<var>member</var>. Rethrow any
                   exceptions.
                 </ol>
@@ -2254,9 +2254,9 @@ document.getElementById("form").addEventListener("submit", e =&gt; {
                 <ol>
                   <li>Deserialize serialized members:
                     <ol>
-                      For each <var>serializeMember</var> let
-                      <var>member</var> be the result of <a data-cite=
-                      "HTML#structureddeserialize">StructuredDeserialize</a> with
+                      For each <var>serializeMember</var>let
+                      <var>member</var>be the result of <a data-cite=
+                      "HTML#structureddeserialize">StructuredDeserialize</a>with
                       <var>serializeMember</var>. Rethrow any exceptions.
                     </ol>
                   </li>
@@ -2438,10 +2438,19 @@ document.getElementById("form").addEventListener("submit", e =&gt; {
         </h2>
         <ul>
           <li>One goal of this specification is to minimize the user
-          interaction required to make a payment. At the same time, user agents
-          must not permit combinations of configurations that would enable
-          invoking Web sites to invoke payment request and receive payments
-          silently.
+          interaction required to make a payment. However, we also want to
+          ensure that the user has an opportunity to consent to making a
+          payment. Because payment handlers are not required to open windows
+          for user interaction, user agents should take necessary steps to
+          provide for some form of user action before <a data-cite=
+          "payment-request#show-method">PaymentRequest.show()</a> resolves. For
+          example, a user agent might do nothing if a payment handler opens a
+          window and the user has an opportunity to confirm a transaction via a
+          button. But if the payment handler does not open a window, or opens a
+          window without an opportunity for user interaction, the browser might
+          prompt the user to confirm the payment handler's behavior before
+          allowing <a data-cite=
+          "payment-request#show-method">PaymentRequest.show()</a> to resolve.
           </li>
         </ul>
       </section>

--- a/index.html
+++ b/index.html
@@ -2440,17 +2440,11 @@ document.getElementById("form").addEventListener("submit", e =&gt; {
           <li>One goal of this specification is to minimize the user
           interaction required to make a payment. However, we also want to
           ensure that the user has an opportunity to consent to making a
-          payment. Because payment handlers are not required to open windows
-          for user interaction, user agents should take necessary steps to
-          provide for some form of user action before <a data-cite=
-          "payment-request#show-method">PaymentRequest.show()</a> resolves. For
-          example, a user agent might do nothing if a payment handler opens a
-          window and the user has an opportunity to confirm a transaction via a
-          button. But if the payment handler does not open a window, or opens a
-          window without an opportunity for user interaction, the browser might
-          prompt the user to confirm the payment handler's behavior before
-          allowing <a data-cite=
-          "payment-request#show-method">PaymentRequest.show()</a> to resolve.
+          payment. Because payment handlers are not required to open a window
+          for user interaction, user agents should take necessary steps to make
+          sure the user (1) is made aware when a payment request is invoked,
+          and (2) has an opportunity to interact with a payment handler before
+          the merchant receives the response from that payment handler.
           </li>
         </ul>
       </section>


### PR DESCRIPTION
in line with:
https://github.com/w3c/payment-handler/wiki/2020-Mar-proposed-changes#mandatory-user-interaction-with-payment-handler-window

Implementation commitment:

 * [ ] Safari (link to issue)
 * [ ] Chrome (link to issue)
 * [ ] Firefox (link to issue)
 * [ ] Edge (public signal)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-handler/pull/365.html" title="Last updated on Apr 22, 2020, 5:31 PM UTC (463bacd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-handler/365/59f9268...463bacd.html" title="Last updated on Apr 22, 2020, 5:31 PM UTC (463bacd)">Diff</a>