### PR TITLE
Remove triggered by user activation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1830,10 +1830,6 @@
           worker</a>'s origin associated with the payment handler, return a
           {{Promise}} resolved with null.
           </li>
-          <li>If this algorithm is not <a>triggered by user activation</a>,
-          return a {{Promise}} rejected with a "{{NotAllowedError}}"
-          {{DOMException}}.
-          </li>
           <li>Let <var>promise</var> be a new {{Promise}}.
           </li>
           <li>Return <var>promise</var> and perform the remaining steps in


### PR DESCRIPTION
closes #358 

The "triggered by user activation" doesn't make sense in this context, because the even is a user agent-generated trusted event (the browser triggered the even to fire as result of user action somewhere else). Payment Request already does the trigger check on `.show()`, so we don't need it here.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jul 9, 2020, 2:01 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fw3c%2Fpayment-handler%2Fpull%2F375%2F4b47c04.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fw3c%2Fpayment-handler%2Fpull%2F375.html)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 sysreq@w3.org to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/payment-handler%23375.)._
</details>
