### PR TITLE
fix: replace deprecated `wg` with `group`

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,10 +56,8 @@
                     w3cid:      67785
                 },
             ],
-            wg:           "Web Payments Working Group",
-            wgURI:        "https://www.w3.org/Payments/WG/",
-            wgPatentURI:  "https://www.w3.org/2004/01/pp-impl/83744/status",
-            testSuiteURI: "https://w3c-test.org/payment-handler/",
+            group: "payments",
+            testSuiteURI: "https://wpt.live/payment-handler/",
             xref: "web-platform",
         };
     </script>


### PR DESCRIPTION
This fixes two ReSpec warnings. @marcoscaceres 

Other errors should be fixed by other PRs.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/saschanaz/payment-handler/pull/385.html" title="Last updated on Apr 1, 2021, 7:51 PM UTC (bcaf90b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-handler/385/4b4525f...saschanaz:bcaf90b.html" title="Last updated on Apr 1, 2021, 7:51 PM UTC (bcaf90b)">Diff</a>