### PR TITLE
Editorial: fix up HTML xrefs

### DIFF
--- a/index.html
+++ b/index.html
@@ -665,9 +665,8 @@
             <dd>
               The <a>sizes</a> member is used to specify the
               <a>ImageObject</a>'s sizes. It follows the spec of sizes member
-              in <a data-cite="HTML#the-link-element">HTML link element</a>,
-              which is a string consisting of an <a data-cite=
-              "HTML#unordered-set-of-unique-space-separated-tokens">unordered
+              in HTML [^link^] element,
+              which is a string consisting of an <a>unordered
               set of unique space-separated tokens</a> which are [=ASCII
               case-insensitive=] that represents the dimensions of an image.
               Each keyword is either an [=ASCII case-insensitive=] match for
@@ -720,7 +719,7 @@
                 </li>
                 <li>Let <var>url</var> be the result of parsing
                 <var>image</var>.<a data-lt="ImageObject.src">src</a> with the
-                <a>context object</a>'s <a>relevant settings object</a>'s
+                <a>this</a>'s <a>relevant settings object</a>'s
                 [=environment settings object/api base url=].
                 </li>
                 <li>If <var>url</var> is failure, then return an empty
@@ -2319,9 +2318,7 @@ document.getElementById("form").addEventListener("submit", e =&gt; {
             <ol>
               <li>Decrement the |event|'s <a>pending promises count</a> by one.
               </li>
-              <li>Let <var>registration</var> be the <a data-cite=
-              "HTML#context-object">context object</a>'s <a data-cite=
-              "HTML#relevant-settings-object">relevant global object</a>'s
+              <li>Let <var>registration</var> be the <a>this</a>'s <a>relevant global object</a>'s
               associated <a>service worker</a>'s <a>containing service worker
               registration</a>.
               </li>


### PR DESCRIPTION
"Context object" is not a thing anymore.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-handler/pull/387.html" title="Last updated on Apr 26, 2021, 9:39 AM UTC (17f23c1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-handler/387/7d1333e...17f23c1.html" title="Last updated on Apr 26, 2021, 9:39 AM UTC (17f23c1)">Diff</a>