### PR TITLE
generate WD snapshot

### DIFF
--- a/.github/workflows/pr-push.yml
+++ b/.github/workflows/pr-push.yml
@@ -14,3 +14,6 @@ jobs:
           W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
           W3C_WG_DECISION_URL: "https://www.w3.org/2016/04/14-wpwg-minutes#item02"
           W3C_NOTIFICATIONS_CC: "${{ secrets.CC }}"
+          W3C_BUILD_OVERRIDE: |
+            shortName: payment-handler
+            specStatus: WD


### PR DESCRIPTION
spec-prod currently generates an ED instead of a WD. That PR fixes that.