### PR TITLE
[Spec] Remove user-identifiable information from canMakePayment

### DIFF
--- a/index.html
+++ b/index.html
@@ -1397,7 +1397,7 @@
                 Algorithm</a>.
               </dd>
               <dt>
-                <a data-lt="CanMakePaymentEvent.modifiers">modifiers</a>
+                <a data-lt="PaymentRequestEvent.modifiers">modifiers</a>
               </dt>
               <dd>
                 The result of executing the <a>Modifiers Population

--- a/index.html
+++ b/index.html
@@ -816,18 +816,10 @@
         <pre class="idl">
           [Exposed=ServiceWorker]
           interface CanMakePaymentEvent : ExtendableEvent {
-            constructor(DOMString type, optional CanMakePaymentEventInit eventInitDict = {});
-            readonly attribute USVString topOrigin;
-            readonly attribute USVString paymentRequestOrigin;
-            readonly attribute FrozenArray&lt;PaymentMethodData&gt; methodData;
+            constructor(DOMString type);
             undefined respondWith(Promise&lt;boolean&gt; canMakePaymentResponse);
           };
         </pre>
-        <p>
-          The <dfn>topOrigin</dfn>, <dfn>paymentRequestOrigin</dfn>,
-          <dfn>methodData</dfn>, and <dfn>modifiers</dfn> members share their
-          definitions with those defined for {{PaymentRequestEvent}}.
-        </p>
         <section>
           <h2>
             <dfn>respondWith()</dfn> method
@@ -835,23 +827,6 @@
           <p>
             This method is used by the payment handler to indicate whether it
             can respond to a payment request.
-          </p>
-        </section>
-        <section data-dfn-for="CanMakePaymentEventInit">
-          <h2>
-            <dfn>CanMakePaymentEventInit</dfn> dictionary
-          </h2>
-          <pre class="idl">
-            dictionary CanMakePaymentEventInit : ExtendableEventInit {
-              USVString topOrigin;
-              USVString paymentRequestOrigin;
-              sequence&lt;PaymentMethodData&gt; methodData;
-            };
-          </pre>
-          <p>
-            The <dfn>topOrigin</dfn>, <dfn>paymentRequestOrigin</dfn>, and
-            <dfn>methodData</dfn> members share their definitions with those
-            defined for {{PaymentRequestEvent}}.
           </p>
         </section>
       </section>
@@ -875,40 +850,8 @@
           <li>
             <p>
               <a>Fire Functional Event</a> "<code>canmakepayment</code>" using
-              <a>CanMakePaymentEvent</a> on <var>registration</var> with the
-              following properties:
+              <a>CanMakePaymentEvent</a> on <var>registration</var>.
             </p>
-            <dl>
-              <dt>
-                <a data-lt="CanMakePaymentEvent.topOrigin">topOrigin</a>
-              </dt>
-              <dd>
-                the [=serialization of an origin=] of the top level payee web
-                page.
-              </dd>
-              <dt>
-                <a data-lt=
-                "CanMakePaymentEvent.paymentRequestOrigin">paymentRequestOrigin</a>
-              </dt>
-              <dd>
-                the [=serialization of an origin=] of the context where
-                PaymentRequest was initialized.
-              </dd>
-              <dt>
-                <a data-lt="CanMakePaymentEvent.methodData">methodData</a>
-              </dt>
-              <dd>
-                The result of executing the <a>MethodData Population
-                Algorithm</a>.
-              </dd>
-              <dt>
-                <a data-lt="CanMakePaymentEvent.modifiers">modifiers</a>
-              </dt>
-              <dd>
-                The result of executing the <a>Modifiers Population
-                Algorithm</a>.
-              </dd>
-            </dl>
           </li>
         </ol>
       </section>
@@ -1944,16 +1887,24 @@ document.getElementById("form").addEventListener("submit", e =&gt; {
           </li>
           <li>In a browser that supports Payment Handler API, when a merchant
           creates a PaymentRequest object with URL-based payment method
-          identifiers, <a>CanMakePaymentEvent</a> will fire in registered
-          payment handlers from a finite number of origins: the origins of the
+          identifiers, a <a>CanMakePaymentEvent</a> will fire in registered
+          payment handlers from a finite set of origins: the origins of the
           payment method manifests and their <a>supported origins</a>. This
-          means that a registered payment handler will know that a user has
-          visited a website before the user has selected that payment handler
-          to complete a transaction. This behavior is similar to the status quo
-          where a merchant embeds a third-party iframe in a checkout page.
-          However, because user agents enable users to disable the
-          <a>CanMakePaymentEvent</a> and users can choose to uninstall payment
-          handlers, this approach improves upon the iframe status quo.
+          event is fired before the user has selected that payment handler,
+          but it contains no information about the triggering origin (i.e.,
+          the merchant website) and so cannot be used to track users directly.
+          <li>We acknowledge the risk of a timing attack via
+          <a>CanMakePaymentEvent</a>:
+          <ul>
+            <li>A merchant website sends notice via a backend channel (e.g., the
+            fetch API) to a payment handler origin, sharing that they are about
+            to construct a PaymentRequest object.</li>
+            <li>The merchant website then constructs the PaymentRequest,
+            triggering a <a>CanMakePaymentEvent</a> to be fired at the installed
+            payment handler.</li>
+            <li>That payment handler contacts its own origin, and on the server
+            side attempts to join the two requests.</li>
+          </ul>
           </li>
           <li>User agents should allow users to disable support for the
           <a>CanMakePaymentEvent</a>.


### PR DESCRIPTION
The “canmakepayment” service worker event lets the merchant know whether the user has a card on file in an installed payment app. It silently passes the merchant's origin and arbitrary data to a service worker from payment app origin. This cross-origin communication happens on PaymentRequest construction in JavaScript, does not require a user gesture, and does not show any user interface. As such, it is a potential source of silent user tracking in a post-3p cookies world.

See #401 for discussions around use-cases for the canmakepayment event.

The following tasks have been completed:

 * [x] web platform tests (link) - N/A (tests are sadly currently in a poor enough state that the entire test suite needs rewritten)
 * [x] MDN Docs added - N/A? (I cannot locate PaymentHandler docs on MDN...)

Implementation commitment:

 * [x] Safari - N/A, does not ship PaymentHandler
 * [x] Chrome ([link to issue](https://groups.google.com/u/1/a/chromium.org/g/blink-dev/c/AM2bwKxXacQ))
 * [x] FirefoxN/A, does not ship PaymentRequest or PaymentHandler
 * [ ] Edge (public signal)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/stephenmcgruer/payment-handler/pull/404.html" title="Last updated on Dec 14, 2022, 12:37 PM UTC (5750402)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-handler/404/d61d41c...stephenmcgruer:5750402.html" title="Last updated on Dec 14, 2022, 12:37 PM UTC (5750402)">Diff</a>