### PR TITLE
Just-in-time (JIT) registration

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,9 +152,10 @@
         (e.g., when the user pushes a button on a checkout page), the user
         agent computes a list of candidate payment handlers, comparing the
         payment methods accepted by the merchant with those supported by
-        registered payment handlers. For payment methods that support
-        additional filtering, <a>CanMakePaymentEvent</a> is used as part of
-        determining whether there is a match.
+        registered payment handlers and those payment handlers that are
+        available for registration just-in-time (JIT). For payment methods that
+        support additional filtering, <a>CanMakePaymentEvent</a> is used as part
+        of determining whether there is a match.
         </li>
         <li>The user agent displays a set of choices to the user: the
         registered <a data-lt="PaymentManager.instruments">instruments</a> of
@@ -288,10 +289,21 @@
         Registration
       </h2>
       <p>
-        One registers a payment handler with the user agent when assigning the
-        first {{PaymentInstrument}} to it through the
-        {{PaymentInstruments/set()}} method.
+        One registers a payment handler with the user agent when either
+        assigning the first {{PaymentInstrument}} to it through the
+        {{PaymentInstruments/set()}} method or through a just-in-time (JIT)
+        registration mechanism.
       </p>
+      <section>
+        <h2>
+          Just-in-time registration
+        </h2>
+        <p>
+          If a payment handler is not registered when a merchant invokes
+          {{PaymentRequest/show()}} method, a user agent may allow the user to
+          register this payment handler at this time.
+        </p>
+      </section>
       <section data-dfn-for="ServiceWorkerRegistration">
         <h2>
           Extension to the `ServiceWorkerRegistration` interface

--- a/index.html
+++ b/index.html
@@ -151,11 +151,16 @@
         [[payment-request]] method <a>canMakePayment()</a> or <a>show()</a>
         (e.g., when the user pushes a button on a checkout page), the user
         agent computes a list of candidate payment handlers, comparing the
-        payment methods accepted by the merchant with those supported by
-        registered payment handlers and those payment handlers that are
-        available for registration just-in-time (JIT). For payment methods that
-        support additional filtering, <a>CanMakePaymentEvent</a> is used as part
-        of determining whether there is a match.
+        payment methods accepted by the merchant with those known to the user
+        agent through any number of mechanisms, including, but not limited to:
+        <ul>
+          <li>Those previously registered through this API.</li>
+          <li>Those that may be registered through this API during the course of
+          the transaction, e.g., identified through a <a>payment method
+          manifest</a>.</li>
+          <li>Those registered through other mechanisms, e.g., the operating
+          system.</li>
+        </ul>
         </li>
         <li>The user agent displays a set of choices to the user: the
         registered <a data-lt="PaymentManager.instruments">instruments</a> of
@@ -301,7 +306,16 @@
         <p>
           If a payment handler is not registered when a merchant invokes
           {{PaymentRequest/show()}} method, a user agent may allow the user to
-          register this payment handler at this time.
+          register this payment handler just-in-time.
+        </p>
+        <h3>
+          <em>Non-normative</em>
+        </h3>
+        <p>
+          A user agent may perform just-in-time installation by deriving payment
+          handler information from the <a>payment method manifest</a> that is
+          found through the <a>URL-based payment method identifier</a> that the
+          merchant requested.
         </p>
       </section>
       <section data-dfn-for="ServiceWorkerRegistration">

--- a/index.html
+++ b/index.html
@@ -308,9 +308,7 @@
           {{PaymentRequest/show()}} method, a user agent may allow the user to
           register this payment handler just-in-time.
         </p>
-        <h3>
-          <em>Non-normative</em>
-        </h3>
+        <p><em>The remaining content of this section is non-normative.</em></p>
         <p>
           A user agent may perform just-in-time installation by deriving payment
           handler information from the <a>payment method manifest</a> that is

--- a/index.html
+++ b/index.html
@@ -306,7 +306,7 @@
         <p>
           If a payment handler is not registered when a merchant invokes
           {{PaymentRequest/show()}} method, a user agent may allow the user to
-          register this payment handler just-in-time.
+          register this payment handler during the transaction ("just-in-time").
         </p>
         <p><em>The remaining content of this section is non-normative.</em></p>
         <p>


### PR DESCRIPTION
Briefly mention that just-in-time (JIT) registration is possible for service worker based payment handlers.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rsolomakhin/payment-handler/pull/407.html" title="Last updated on Jan 24, 2023, 3:48 PM UTC (a5b45b6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-handler/407/3009b75...rsolomakhin:a5b45b6.html" title="Last updated on Jan 24, 2023, 3:48 PM UTC (a5b45b6)">Diff</a>